### PR TITLE
Add TODO annotations and index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,9 @@ desktop/dist-electron/
 # MOBILE APP SPECIFIC (Cordova)
 mobile/platforms/
 mobile/plugins/
+voice-assistant-apps/mobile/platforms/
+voice-assistant-apps/mobile/plugins/
+# TODO: Obige Pfade anpassen, damit Build-Artefakte im Subordner ignoriert werden
 mobile/node_modules/
 mobile/www/cordova.js
 mobile/www/cordova_plugins.js

--- a/README.md
+++ b/README.md
@@ -633,8 +633,10 @@ Dieses Projekt ist unter der [MIT License](LICENSE) lizenziert.
 ## 🔗 Weiterführende Links
 
 - 📚 **[Hardware Setup Guide](docs/hardware-setup.md)**
+- <!-- TODO: docs/hardware-setup.md erstellen oder Link anpassen -->
 - 🏗️ **[Architecture Deep Dive](docs/architecture.md)**
 - 🔧 **[Development Guide](docs/development.md)**
+- <!-- TODO: docs/development.md erstellen oder Link entfernen -->
 - 🤝 **[Contributing Guidelines](CONTRIBUTING.md)**
 - 🐛 **[Issues & Support](https://github.com/your-repo/issues)**
 - 💬 **[Discussions](https://github.com/your-repo/discussions)**

--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -1,0 +1,28 @@
+# TODO Index
+
+Eine Übersicht aller mit `TODO` gekennzeichneten Stellen im Projekt.
+
+- **README.md**
+  - Zeile 636: docs/hardware-setup.md erstellen oder Link anpassen
+  - Zeile 639: docs/development.md erstellen oder Link entfernen
+- **docs/skill-system.md**
+  - Zeile 1: Dokumentation des Skill-Systems ergänzen
+- **.gitignore**
+  - Zeile 161: Pfade für mobile Build-Artefakte korrigieren
+- **voice-assistant-apps/shared/ index.html**
+  - Zeile 1: Datei ohne führendes Leerzeichen umbenennen
+  - Weitere TODOs ab Zeile 569 für GUI-Überarbeitung
+- **voice-assistant-apps/desktop/src/index.hmtl**
+  - Zeile 1: Datei in index.html umbenennen und Inhalte aus gui/index.html integrieren
+- **gui/app.js**
+  - Zeilen 1–6: Web-GUI Logik und Animationen implementieren
+- **gui/index.html**
+  - Diverse TODOs ab Zeile 568 für Design- und Layoutanpassungen
+- **scripts/start-stt.sh**
+  - Zeile 2: STT-Dienst Startskript implementieren
+- **scripts/start-tts.sh**
+  - Zeile 2: TTS-Dienst Startskript implementieren
+- **scripts/ws-server/install.sh**
+  - Zeile 11: Service-Datei mit installieren
+- **ws-server/ws-server.py**
+  - Zeile 95: Lokale Skill-Implementierung anbinden

--- a/docs/skill-system.md
+++ b/docs/skill-system.md
@@ -1,0 +1,1 @@
+<!-- TODO: Dokumentation des Skill-Systems ergänzen -->

--- a/scripts/start-stt.sh
+++ b/scripts/start-stt.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+# TODO: STT-Dienst starten und Logs ausgeben

--- a/scripts/start-tts.sh
+++ b/scripts/start-tts.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+# TODO: TTS-Dienst starten und Logs ausgeben

--- a/scripts/ws-server/install.sh
+++ b/scripts/ws-server/install.sh
@@ -8,4 +8,5 @@ pip3 install websockets aiohttp faster-whisper piper-tts
 echo "Creating directory..."
 mkdir -p ~/ws-server
 cp ws-server.py ~/ws-server/
+# TODO: ws-server.service ebenfalls kopieren und installieren
 echo "Done. Enable service with: sudo systemctl enable ws-server.service"

--- a/voice-assistant-apps/desktop/src/index.hmtl
+++ b/voice-assistant-apps/desktop/src/index.hmtl
@@ -1,3 +1,4 @@
+<!-- TODO: Datei in index.html umbenennen und Inhalte aus gui/index.html integrieren -->
 <!DOCTYPE html>
 <html lang="de">
 <head>

--- a/voice-assistant-apps/shared/ index.html
+++ b/voice-assistant-apps/shared/ index.html
@@ -1,3 +1,4 @@
+<!-- TODO: Datei ohne führendes Leerzeichen umbenennen -->
 <!DOCTYPE html>
 <html lang="de">
 <head>

--- a/ws-server/ws-server.py
+++ b/ws-server/ws-server.py
@@ -92,6 +92,7 @@ async def route_to_n8n(text: str) -> str:
 async def route_intent(text: str) -> str:
     t = text.lower().strip()
     if any(word in t for word in ["licht", "musik", "volume", "timer"]):
+        # TODO: Lokale Skill-Implementierung anbinden
         return "[lokale Skills noch nicht implementiert]"
     elif any(word in t for word in ["wetter", "garage", "status", "zeit"]):
         return await route_to_n8n(t)


### PR DESCRIPTION
## Summary
- add missing TODO notes and create TODO-Index.md
- mark missing documents in README
- note skill system documentation placeholder
- record missing service installation and script stubs
- highlight incomplete GUI and ignore paths

## Testing
- `npm test --workspaces` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688cf3bfa04c8324a5f06dcfb34c2669