### PR TITLE
Add GUI TODO references

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -1,0 +1,30 @@
+# TODO Index
+
+Diese Datei listet alle TODO-Kommentare, die sich auf die Anpassungen aus [docs/GUI-TODO.md](docs/GUI-TODO.md) beziehen.
+
+| Datei | Zeile | Kommentar |
+|-------|------:|-----------|
+| gui/app.js | 1-6 | Grundlegende Aufgaben zur neuen Web-GUI |
+| gui/index.html | 568 | Buttons rund gestalten |
+| gui/index.html | 799 | Container transparenter gestalten |
+| gui/index.html | 1136 | Status-Anzeigen sollen ein neues Fenster öffnen |
+| gui/index.html | 1383 | Status-Anzeigen auf eigene Seite auslagern |
+| gui/index.html | 1396 | Texteingabe und Senden-Button unten fixieren |
+| gui/index.html | 1407 | Neues Icon verwenden und Beschriftung entfernen |
+| gui/index.html | 1430 | Antworttext als Matrix-Regen einblenden |
+| gui/index.html | 1439 | Sprachaufnahme-Button neben Senden-Button |
+| gui/index.html | 1443 | Neue minimalistische Icons |
+| gui/index.html | 1859 | Status-Anzeigen auf separater Seite darstellen |
+| voice-assistant-apps/shared/app.js | 3 | GUI-Anpassungen berücksichtigen |
+| voice-assistant-apps/shared/app.js | 486 | Matrix-Regen Animation implementieren |
+| voice-assistant-apps/shared/ index.html | 568 | Buttons rund gestalten |
+| voice-assistant-apps/shared/ index.html | 799 | Antwort-Container transparenter |
+| voice-assistant-apps/shared/ index.html | 1382 | Status-Anzeigen über Menü erreichbar |
+| voice-assistant-apps/shared/ index.html | 1394 | Texteingabe und Senden-Button unten |
+| voice-assistant-apps/shared/ index.html | 1405 | Neues Icon verwenden |
+| voice-assistant-apps/shared/ index.html | 1428 | Matrix-Stil Antwortanimation |
+| voice-assistant-apps/shared/ index.html | 1437 | Sprachaufnahme-Button verschieben |
+| voice-assistant-apps/shared/ index.html | 1441 | Icon ersetzen, Beschriftung entfernen |
+| voice-assistant-apps/shared/ index.html | 1857 | Status-Seite über Menü |
+| voice-assistant-apps/desktop/src/index.hmtl | 4 | GUI anpassen laut TODO-Liste |
+| voice-assistant-apps/desktop/src/desktop-app.js | 2 | Umsetzung der GUI-TODOs |

--- a/gui/index.html
+++ b/gui/index.html
@@ -1856,6 +1856,7 @@
     }
 
     function showSystemInfo() {
+      // TODO: Status-Anzeigen auf separater Seite darstellen
       document.getElementById('settingsMenu').classList.remove('active');
       
       const info = {

--- a/voice-assistant-apps/desktop/src/desktop-app.js
+++ b/voice-assistant-apps/desktop/src/desktop-app.js
@@ -1,4 +1,5 @@
 // Desktop-spezifische Erweiterungen für Electron
+// TODO: Umsetzung der GUI-TODOs (Status-Seite, Icons, Animation)
 class DesktopVoiceAssistant {
   constructor() {
     this.isElectron = window.electronAPI?.isElectron || false;

--- a/voice-assistant-apps/desktop/src/index.hmtl
+++ b/voice-assistant-apps/desktop/src/index.hmtl
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
+  <!-- TODO: GUI gemäß docs/GUI-TODO.md anpassen -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>KI-Sprachassistent</title>

--- a/voice-assistant-apps/shared/ index.html
+++ b/voice-assistant-apps/shared/ index.html
@@ -1854,6 +1854,7 @@
     }
 
     function showSystemInfo() {
+      // TODO: Status-Anzeigen auf separater Seite darstellen
       document.getElementById('settingsMenu').classList.remove('active');
       
       const info = {

--- a/voice-assistant-apps/shared/app.js
+++ b/voice-assistant-apps/shared/app.js
@@ -483,6 +483,7 @@ class VoiceAssistantCore {
     const responseElement = document.getElementById('response');
     if (responseElement) {
       responseElement.innerHTML = `<div class="response-content">${content}</div>`;
+      // TODO: Antworttext per Matrix-Regen animieren (siehe docs/GUI-TODO.md)
       responseElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
   }


### PR DESCRIPTION
## Summary
- add TODO references in desktop and shared code
- index status page placeholder
- create a central TODO index

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688cf34a82588324976cad4f4dd77e0e