### PR TITLE
Add missing TODO placeholders

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -36,6 +36,10 @@ Eine Übersicht aller mit `TODO` gekennzeichneten Stellen im Projekt.
   - Zeile 639: docs/development.md erstellen oder Link entfernen
 - **docs/skill-system.md**
   - Zeile 1: Dokumentation des Skill-Systems ergänzen
+- **docs/hardware-setup.md**
+  - Zeile 1: Anleitung zum Hardware-Setup erstellen
+- **docs/development.md**
+  - Zeile 1: Ausführlichen Development Guide verfassen
 - **.gitignore**
   - Zeile 161: Pfade für mobile Build-Artefakte korrigieren
 - **voice-assistant-apps/shared/ index.html**
@@ -53,5 +57,7 @@ Eine Übersicht aller mit `TODO` gekennzeichneten Stellen im Projekt.
   - Zeile 2: TTS-Dienst Startskript implementieren
 - **scripts/ws-server/install.sh**
   - Zeile 11: Service-Datei mit installieren
+- **scripts/install_all_nodes.sh**
+  - Zeile 58: Pfad zum Installationsskript korrigieren
 - **ws-server/ws-server.py**
   - Zeile 95: Lokale Skill-Implementierung anbinden

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,3 @@
+<!-- TODO: Ausführlichen Development Guide erstellen -->
+
+Dieser Platzhalter verhindert einen toten Link aus der README.

--- a/docs/hardware-setup.md
+++ b/docs/hardware-setup.md
@@ -1,0 +1,3 @@
+<!-- TODO: Ausführliche Anleitung zum Hardware-Setup ergänzen -->
+
+Dieser Platzhalter verhindert einen toten Link aus der README.

--- a/scripts/install_all_nodes.sh
+++ b/scripts/install_all_nodes.sh
@@ -55,6 +55,7 @@ apply_configs $ODROID_HOST odroid
 
 ## WebSocket-Server (lokal)
 log "🧠 Starte lokale ws-server Installation..."
+# TODO: Pfad anpassen – Skript heißt install.sh, nicht install-ws.sh
 bash ./scripts/ws-server/install-ws.sh || abort "Fehler bei ws-server Installation"
 sudo cp ./ws-server/ws-server.service /etc/systemd/system/ws-server.service
 sudo systemctl daemon-reload && sudo systemctl enable ws-server && sudo systemctl start ws-server


### PR DESCRIPTION
## Summary
- add placeholder docs to prevent broken links
- note wrong ws-server install path in installer
- update TODO-Index with new entries

## Testing
- `npm test --prefix voice-assistant-apps/desktop` *(fails: Missing script)*
- `python3 -m py_compile ws-server/ws-server.py`

------
https://chatgpt.com/codex/tasks/task_e_688d065249808324a174ebd352fc01b3