### PR TITLE
Document missing steps

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -61,3 +61,11 @@ Eine Übersicht aller mit `TODO` gekennzeichneten Stellen im Projekt.
   - Zeile 58: Pfad zum Installationsskript korrigieren
 - **ws-server/ws-server.py**
   - Zeile 95: Lokale Skill-Implementierung anbinden
+- **scripts/install-piper.sh**
+  - Zeile 2: Piper TTS Installationsschritte implementieren
+- **scripts/setup-tailscale.sh**
+  - Zeile 2: Tailscale/Headscale Setup-Skript ausarbeiten
+- **docs/headscale-setup.md**
+  - Zeile 5: Nutzung der systemd-Datei beschreiben
+- **docs/GUI-TODO.md**
+  - Zeile 20: Weitere Animationsideen ergänzen

--- a/docs/GUI-TODO.md
+++ b/docs/GUI-TODO.md
@@ -4,15 +4,17 @@
 
 - Status Anzeigen auf extra Page über Menu erreichbar
 - Texteingabe + Sende Button nach ganz unten
-- Button Spracheingabe starten neben Senden Button 
+- Button Spracheingabe starten neben Senden Button
 
 ## Design Änderungen
 
 - Text Antwort Container transparent
-- In den Buttons keine Schrift, nur Icons 
+- In den Buttons keine Schrift, nur Icons
 - Buttons rund, nicht eckig
 - Allgemein neue Icons, keine Bilder sondern schlichte standart Icons (ChatGPT App)
 
 ## Animation erweitern
 
-" Die Antwort (der Text der Antwort Nachricht) soll aus dem "Wabendern Nebel Icon" heraus regnen (Matrix Style Animation)."
+- Die Antwort (der Text der Antwort Nachricht) soll aus dem "Wabendern Nebel Icon" heraus regnen (Matrix Style Animation).
+
+<!-- TODO: Weitere Animationsideen ergänzen und Beispiele verlinken -->

--- a/docs/headscale-setup.md
+++ b/docs/headscale-setup.md
@@ -2,6 +2,7 @@
 
 Dieses Dokument beschreibt die Einrichtung von Headscale als selbstgehostete Alternative zu Tailscale für ein sicheres Mesh-VPN zwischen den Nodes (Raspi 4, Raspi 400, Odroid, Server).
 
+<!-- TODO: Schritte zum Einrichten der systemd-Datei aus Headscale/headscale.systemd.service beschreiben -->
 ---
 
 ## 📦 Voraussetzungen

--- a/scripts/install-piper.sh
+++ b/scripts/install-piper.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# TODO: Implement installation steps for Piper TTS (dependencies, model download)
+

--- a/scripts/setup-tailscale.sh
+++ b/scripts/setup-tailscale.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# TODO: Implement Tailscale or Headscale setup instructions
+


### PR DESCRIPTION
## Summary
- fix truncated GUI TODO list
- note systemd instructions missing in headscale setup
- stub out Piper and Tailscale install scripts
- update TODO-Index with new TODOs

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in mobile app *(fails: no test specified)*
- `python3 -m py_compile ws-server/ws-server.py`

------
https://chatgpt.com/codex/tasks/task_e_688d0c173b88832496f866b3719d548a