### PR TITLE
Default to ML intent classification with keyword fallback

### DIFF
--- a/backend/ws-server/intent_classifier.py
+++ b/backend/ws-server/intent_classifier.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Optional
 
 try:
@@ -8,17 +9,22 @@ except Exception:  # pragma: no cover - optional dependency
 
 logger = logging.getLogger(__name__)
 
-class IntentClassifier:
-    """Optional einfacher Intent-Klassifizierer."""
 
-    def __init__(self, model_path: Optional[str] = None):
+class IntentClassifier:
+    """Intent-Klassifizierer mit Keyword-Fallback."""
+
+    def __init__(self, model_path: Optional[str] = "models/intent_classifier.bin"):
         self.model = None
-        if model_path and joblib:
+        if joblib and model_path and Path(model_path).exists():
             try:
                 self.model = joblib.load(model_path)
                 logger.info("Intent-Model geladen: %s", model_path)
             except Exception as exc:
                 logger.error("Konnte Intent-Model nicht laden: %s", exc)
+        else:
+            logger.warning(
+                "Kein Intent-Model geladen, verwende Schlüsselwort-Fallback"
+            )
 
     def classify(self, text: str) -> str:
         if self.model:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ Ein verteilter Sprachassistent, der lokal Sprache versteht (STT), antwortet (TTS
 
 * **STT**: [`faster-whisper`](https://github.com/guillaumekln/faster-whisper)
 * **TTS**: [`piper`](https://github.com/rhasspy/piper)
-* **Intent-Routing**: Leitet einfache und komplexe Anfragen weiter
+* **Intent-Routing**: ML-basierte Klassifikation mit Fallback
 * **WebSocket-Server**: `ws_server_fastapi.py` (FastAPI-basierter Nachfolger)
 
 ### 🧰 Raspi 400 (4 GB)
@@ -41,7 +41,8 @@ Ein verteilter Sprachassistent, der lokal Sprache versteht (STT), antwortet (TTS
 ```mermaid
 flowchart LR
   Raspi400 -->|Spracheingabe (Mic)| Raspi4
-  Raspi4 -->|Transkript (Text)| Odroid
+  Raspi4 -->|Transkript| Klassifikation
+  Klassifikation -->|Intent| Odroid
   Odroid -->|Antwort / Workflow| Raspi4
   Raspi4 -->|Sprachausgabe| Raspi400
 ```

--- a/docs/skill-system.md
+++ b/docs/skill-system.md
@@ -2,7 +2,9 @@
 
 Der WebSocket-Server lädt zur Laufzeit Skills aus dem Ordner
 `backend/ws-server/skills`. Jeder Skill implementiert die Klasse
-`BaseSkill` und kann so modular erweitert werden.
+`BaseSkill` und kann so modular erweitert werden. Eine ML-gestützte
+Intent-Klassifikation entscheidet standardmäßig, welcher Skill aktiv ist.
+Fällt das Modell aus, greift eine Schlüsselwort-Heuristik als Fallback.
 
 ```python
 class BaseSkill:
@@ -41,3 +43,10 @@ class TimeSkill(BaseSkill):
 
 Neue Dateien nach diesem Muster ablegen, schon stehen sie dem
 Sprachassistenten ohne weitere Änderungen zur Verfügung.
+
+### Intent-Klassifikation
+
+Bei jeder Texteingabe bestimmt ein ML-Modell das passende
+Intent-Label (z. B. `time_query` oder `greeting`). Das Ergebnis wird
+für die Skill-Auswahl genutzt. Ist kein Modell vorhanden, wird eine
+Schlüsselwort-basierte Fallback-Erkennung verwendet.

--- a/env.example
+++ b/env.example
@@ -16,7 +16,8 @@ N8N_URL=http://odroid.local:5678/webhook/intent
 
 # === Skills & ML ===
 ENABLED_SKILLS=TimeSkill,GreetingSkill,GratitudeSkill
-INTENT_MODEL=none
+# Optional: Pfad zum Intent-Model (fallback auf models/intent_classifier.bin)
+# INTENT_MODEL=models/intent_classifier.bin
 
 # === Retry Settings ===
 RETRY_LIMIT=3


### PR DESCRIPTION
## Summary
- always initialize `IntentClassifier` with default model path
- route transcription through ML classifier on every request with fallback heuristics
- document new intent flow and remove `INTENT_MODEL=none` toggle

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'websockets', No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688de2e8a5b48324ba3d6aa1034f6b17