### PR TITLE
Improve STT and TTS handling

### DIFF
--- a/docs/tts-engines.md
+++ b/docs/tts-engines.md
@@ -1,0 +1,35 @@
+# TTS Engines
+
+This project can synthesize speech using different engines. Defaults are read from `.env` and can be overridden per request.
+
+## `.env` settings
+
+- `TTS_ENGINE` – default engine (`"piper"` or `"kokoro"`)
+- `TTS_VOICE` – default voice identifier
+- `TTS_SPEED` – playback speed (1.0 = normal)
+- `TTS_VOLUME` – output volume factor (1.0 = normal)
+
+## WebSocket overrides
+
+Clients may override any of the settings by including them in the request:
+
+```json
+{
+  "type": "speak",
+  "text": "Wie spät ist es?",
+  "tts_engine": "piper",
+  "tts_voice": "de-eva_k-low",
+  "tts_speed": 1.2,
+  "tts_volume": 0.8
+}
+```
+
+## Available voices
+
+### Piper
+- `de-thorsten-low` (German)
+- `en-amy-low` (English)
+
+### Kokoro
+- `af_sarah` (English)
+- `de_female` (German)

--- a/env.example
+++ b/env.example
@@ -29,7 +29,8 @@ STT_DEVICE=cpu
 STT_PRECISION=int8
 
 # === TTS-Konfiguration ===
-TTS_MODEL=de-thorsten-low.onnx
+TTS_ENGINE=piper
+TTS_VOICE=de-thorsten-low
 TTS_SPEED=1.0
 TTS_VOLUME=1.0
 


### PR DESCRIPTION
## Summary
- refactor STT preprocessing to keep audio in memory and skip temporary files
- switch Piper TTS to `piper-tts` library with runtime-configurable voice, speed and volume
- document available engines and parameters

## Testing
- `pytest`
- `python backend/test_tts_system.py` *(fails: Piper TTS Initialisierung fehlgeschlagen: Kein Piper-Modell für Stimme 'de-thorsten-low' gefunden)*

------
https://chatgpt.com/codex/tasks/task_e_688de4f4000c83248d6de3f9e80a37ca