### PR TITLE
Add theme switching to mobile GUI

### DIFF
--- a/gui/app.js
+++ b/gui/app.js
@@ -122,6 +122,24 @@ class VoiceAssistantGUI {
             });
         }
 
+        // Theme toggle
+        const themeToggle = document.getElementById('themeToggle');
+        if (themeToggle) {
+            themeToggle.addEventListener('click', () => {
+                const isLight = document.documentElement.classList.toggle('light-mode');
+                themeToggle.textContent = isLight ? '🌙' : '☀️';
+                localStorage.setItem('theme', isLight ? 'light' : 'dark');
+            });
+
+            const savedTheme = localStorage.getItem('theme');
+            if (savedTheme === 'light') {
+                document.documentElement.classList.add('light-mode');
+                themeToggle.textContent = '🌙';
+            } else {
+                themeToggle.textContent = '☀️';
+            }
+        }
+
         // Keyboard shortcuts
         document.addEventListener('keydown', (event) => {
             // Ctrl/Cmd + Enter for voice input

--- a/gui/index.html
+++ b/gui/index.html
@@ -73,6 +73,18 @@
       --bounce-easing: cubic-bezier(0.68, -0.55, 0.265, 1.55);
     }
 
+    html.light-mode {
+      --bg-primary: #f4f4f5;
+      --bg-secondary: #ffffff;
+      --bg-tertiary: #e4e4e7;
+      --bg-card: rgba(0, 0, 0, 0.03);
+      --text-primary: #18181b;
+      --text-secondary: #3f3f46;
+      --text-muted: #71717a;
+      --glass-bg: rgba(0, 0, 0, 0.05);
+      --glass-border: rgba(0, 0, 0, 0.1);
+    }
+
     /* Reset & Base */
     * {
       margin: 0;
@@ -849,6 +861,9 @@
         <span>KI-Assistent</span>
       </div>
       <div class="nav-actions">
+        <button class="nav-button" id="themeToggle" title="Theme wechseln">
+          ☀️
+        </button>
         <button class="nav-button" id="settingsBtn" title="Einstellungen">
           ⚙️
         </button>


### PR DESCRIPTION
## Summary
- add light-mode CSS variables and theme toggle button
- persist theme selection in localStorage

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e3c9539d88324a619032f2e87e78d