### PR TITLE
Allow token bypass for missing token and update websockets import

### DIFF
--- a/backend/ws-server/auth/token_utils.py
+++ b/backend/ws-server/auth/token_utils.py
@@ -107,23 +107,23 @@ try:
 except Exception:
     pyjwt = None
 
-def verify_token(token: str) -> bool:
+def verify_token(token: Optional[str]) -> bool:
     """
     Nicht-rekursive Token-Prüfung:
       - JWT_BYPASS=1  -> immer True (nur DEV!)
       - JWT_ALLOW_PLAIN=1: Token == JWT_SECRET erlaubt (z.B. "devsecret")
       - sonst: HS256-JWT gegen JWT_SECRET, falls PyJWT verfügbar
     """
+    # DEV-Bypass ohne Token-Prüfung erlauben
+    if os.getenv('JWT_BYPASS', '0') == '1':
+        return True
+
     if not token:
         return False
 
     t = token.strip()
     if t.lower().startswith('bearer '):
         t = t[7:].strip()
-
-    # DEV-Bypass
-    if os.getenv('JWT_BYPASS', '0') == '1':
-        return True
 
     secret = os.getenv('JWT_SECRET', 'devsecret')
 

--- a/backend/ws-server/ws-server.py
+++ b/backend/ws-server/ws-server.py
@@ -26,6 +26,7 @@ Features integrated from previous versions:
 
 import asyncio
 import websockets
+from websockets.server import WebSocketServerProtocol
 import json
 import base64
 import time
@@ -581,12 +582,12 @@ class ConnectionManager:
     """Manages WebSocket connections with optimized handling"""
     
     def __init__(self, stream_manager: AudioStreamManager, tts_manager: TTSManager):
-        self.active_connections: Dict[str, websockets.WebSocketServerProtocol] = {}
+        self.active_connections: Dict[str, WebSocketServerProtocol] = {}
         self.connection_info: Dict[str, Dict] = {}
         self.stream_manager = stream_manager
         self.tts_manager = tts_manager
         
-    async def register(self, websocket: websockets.WebSocketServerProtocol) -> str:
+    async def register(self, websocket: WebSocketServerProtocol) -> str:
         """Register new WebSocket connection"""
         client_id = uuid.uuid4().hex
         

--- a/testsuite/test_token_utils.py
+++ b/testsuite/test_token_utils.py
@@ -16,3 +16,9 @@ def test_verify_token_plain(monkeypatch):
     monkeypatch.setenv('JWT_BYPASS', '0')
     monkeypatch.setenv('JWT_SECRET', 'devsecret')
     assert verify_token('devsecret') is True
+
+
+def test_verify_token_bypass_allows_empty(monkeypatch):
+    monkeypatch.setenv('JWT_BYPASS', '1')
+    monkeypatch.setenv('JWT_ALLOW_PLAIN', '0')
+    assert verify_token(None) is True


### PR DESCRIPTION
## Summary
- Allow JWT_BYPASS to let clients connect without providing a token
- Add regression test for empty-token bypass
- Import WebSocketServerProtocol from websockets.server to avoid deprecation warning

## Testing
- `python testsuite/run.py --scope backend`
- `pytest testsuite/test_token_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6bea542688324b0155f8d887f2424