### PR TITLE
Increase desktop backend startup timeout

### DIFF
--- a/voice-assistant-apps/desktop/src/main.js
+++ b/voice-assistant-apps/desktop/src/main.js
@@ -181,7 +181,7 @@ function createTray() {
 }
 
 // ---- Backend ----------------------------------------------------------------
-function waitForPort(port, host = '127.0.0.1', retries = 30, delay = 500) {
+function waitForPort(port, host = '127.0.0.1', retries = 240, delay = 500) {
   return new Promise((resolve, reject) => {
     const tryConnect = () => {
       const socket = net.connect(port, host, () => {


### PR DESCRIPTION
## Summary
- expand backend startup waiting period so Electron desktop doesn't time out when backend takes longer to initialize

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6c3743d288324956f4b708446d484