### PR TITLE
fix: robust STT model fallback

### DIFF
--- a/backend/ws-server/ws-server.py
+++ b/backend/ws-server/ws-server.py
@@ -282,7 +282,14 @@ class AsyncSTTEngine:
             # ready-to-use converted models. This prevents startup failures when
             # a PyTorch model repository is mistakenly used.
             if "model.bin" in str(exc) and not self.model_path:
-                alt = f"guillaumekln/whisper-{self.model_size}"
+                # Extract the base model name even if a namespace like "openai/" is
+                # provided (e.g. "openai/whisper-base" -> "base").  Some Hugging Face
+                # repositories such as "openai/whisper-base" only contain the original
+                # PyTorch weights which are missing the required CTranslate2 files.  In
+                # that case we transparently fall back to the official faster-whisper
+                # repository which hosts ready-to-use converted models.
+                base_name = self.model_size.split("/")[-1].replace("whisper-", "")
+                alt = f"Systran/faster-whisper-{base_name}"
                 logger.warning(
                     f"CT2 model not found for '{target}', trying fallback '{alt}'"
                 )


### PR DESCRIPTION
## Summary
- ensure STT engine falls back to official faster-whisper models when a PyTorch model lacking CTranslate2 files is requested
- sanitize model names (e.g. `openai/whisper-base`) before constructing fallback repo IDs

## Testing
- `./va.sh test` *(fails: can't open file '/home/saschi/Sprachassistent/final_server_test.py')*
- `pytest test/test_whisper.py -q` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68a6effe91b88324b34aee26c695bc50