### PR TITLE
Fix faster-whisper config and WebSocket auth

### DIFF
--- a/docs/integration/faster-whisper.md
+++ b/docs/integration/faster-whisper.md
@@ -11,11 +11,16 @@ python3 -m faster_whisper.transcribe audio.wav
 
 ## Troubleshooting
 - Ensure `ffmpeg` is installed for audio conversion.
-- Use `WHISPER_DEVICE=cuda` on systems with CUDA.
+- Use `STT_DEVICE=cuda` on systems with CUDA.
 
 ## .env Example
 ```
-WHISPER_MODEL_SIZE=medium-int8
-WHISPER_DEVICE=cpu
-WHISPER_LANG=de
+STT_MODEL=Systran/faster-whisper-base
+STT_DEVICE=cpu
+STT_PRECISION=int8
 ```
+
+> ⚠️ Using repositories such as `openai/whisper-base` will download the
+> original PyTorch weights which miss the required CTranslate2 files.  Set
+> `STT_MODEL` to the corresponding `Systran/faster-whisper-*` repository to
+> avoid startup warnings and ensure faster-whisper works correctly.

--- a/env.example
+++ b/env.example
@@ -8,9 +8,9 @@ WS_PORT=8001
 WS_TOKEN=mein-geheimer-token
 
 # === STT Configuration ===
-WHISPER_MODEL_SIZE=medium-int8
-WHISPER_DEVICE=cpu
-WHISPER_LANG=de
+STT_MODEL=Systran/faster-whisper-base
+STT_DEVICE=cpu
+STT_PRECISION=int8
 
 # === TTS Configuration ===
 PIPER_MODEL=de-thorsten-low.onnx


### PR DESCRIPTION
## Summary
- automatically map OpenAI Whisper repo names to faster-whisper models
- append auth token and handshake to WebSocket connections
- document new STT environment variables and defaults

## Testing
- `python final_server_test.py` *(fails: Cannot find cached snapshot folder; outgoing traffic disabled)*
- `npm --prefix voice-assistant-apps/desktop test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6f754139883248ac3fe1e8c6454ea