### PR TITLE
Allow missing WS token when plain auth is enabled

### DIFF
--- a/backend/ws-server/auth/token_utils.py
+++ b/backend/ws-server/auth/token_utils.py
@@ -119,6 +119,11 @@ def verify_token(token: Optional[str]) -> bool:
         return True
 
     if not token:
+        # Allow empty tokens when plain-token auth is enabled.  This is
+        # useful in development environments where the desktop client may
+        # not send a token before the local storage is initialised.
+        if os.getenv('JWT_ALLOW_PLAIN', '0') == '1':
+            return True
         return False
 
     t = token.strip()


### PR DESCRIPTION
## Summary
- permit WebSocket connections without a token when `JWT_ALLOW_PLAIN` is set

## Testing
- `./run_tests.sh --scope backend`
- `python - <<'PY' ... verify_token ... PY`


------
https://chatgpt.com/codex/tasks/task_e_68a709b159b88324a0f89d723eef42ca