### PR TITLE
Delay auth until after WebSocket handshake

### DIFF
--- a/voice-assistant-apps/shared/core/VoiceAssistantCore.js
+++ b/voice-assistant-apps/shared/core/VoiceAssistantCore.js
@@ -281,9 +281,7 @@ class VoiceAssistantCore {
           console.warn('Failed to send handshake', e);
         }
 
-        // Optionally send auth capabilities after handshake
-        this.authenticate();
-        this.updateConnectionStatus('connected', '✅ Connected');
+        // Connection established; wait for server confirmation before auth
         this.metrics.reconnections++;
       };
 
@@ -334,6 +332,11 @@ class VoiceAssistantCore {
       vibrate: !!navigator.vibrate,
       serviceWorker: !!navigator.serviceWorker
     };
+  }
+
+  handleConnected(data) {
+    this.updateConnectionStatus('connected', '✅ Connected');
+    this.authenticate();
   }
 
   handleWebSocketMessage(event) {


### PR DESCRIPTION
## Summary
- avoid sending auth message before server handshake completes
- authenticate and mark status once `connected` event is received

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a710df7044832499231076dd6fa3fa