### PR TITLE
Improve WebSocket token handling and handshake robustness

### DIFF
--- a/voice-assistant-apps/shared/core/OptimizedAudioStreamer.js
+++ b/voice-assistant-apps/shared/core/OptimizedAudioStreamer.js
@@ -131,7 +131,17 @@ this.websocket = new WebSocket(wsUrl);
                     this.metrics.connection.connected = true;
                     this.metrics.connection.reconnectAttempts = 0;
 
-                    const streamId = crypto.randomUUID();
+                    // Generate a unique stream identifier.  Some environments
+                    // (notably older Electron builds) may not implement
+                    // `crypto.randomUUID`, so fall back to a Math.random based
+                    // id to ensure the handshake packet is always sent.
+                    let streamId;
+                    try {
+                        streamId = globalThis.crypto?.randomUUID?.();
+                    } catch (_) {}
+                    if (!streamId) {
+                        streamId = Math.random().toString(36).slice(2);
+                    }
                     this.currentStreamId = streamId;
                     try {
                         this.websocket.send(JSON.stringify({

--- a/voice-assistant-apps/shared/core/VoiceAssistantCore.js
+++ b/voice-assistant-apps/shared/core/VoiceAssistantCore.js
@@ -725,7 +725,18 @@ class VoiceAssistantCore {
     // Generate or retrieve JWT token.  The token is also stored under
     // "wsToken" so other components (e.g. OptimizedAudioStreamer) can reuse
     // it when establishing their own WebSocket connections.
-    const token = localStorage.getItem('voice_auth_token') || 'demo-token';
+    // Prefer an existing token from localStorage (either a previously stored
+    // voice_auth_token or wsToken).  Fallback to the development token
+    // "devsecret" so that desktop and web clients behave consistently during
+    // local testing.
+    const token =
+      localStorage.getItem('voice_auth_token') ||
+      localStorage.getItem('wsToken') ||
+      'devsecret';
+
+    // Expose the token under "wsToken" so other components (e.g. the
+    // OptimizedAudioStreamer) can append it automatically to their WebSocket
+    // URLs.
     try { localStorage.setItem('wsToken', token); } catch (_) {}
     return token;
   }


### PR DESCRIPTION
## Summary
- Align client token retrieval with dev defaults and existing wsToken
- Ensure WebSocket handshake works even when `crypto.randomUUID` is unavailable

## Testing
- `bash run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a7187d59dc83249b1ad611abb3319f