### PR TITLE
Stabilize WebSocket handshake and default dev token

### DIFF
--- a/env.example
+++ b/env.example
@@ -5,7 +5,8 @@ WS_HOST=localhost
 WS_PORT=8001
 
 # === Authentication ===
-WS_TOKEN=mein-geheimer-token
+# Default development token used by the desktop client
+WS_TOKEN=devsecret
 
 # === STT Configuration ===
 STT_MODEL=Systran/faster-whisper-base


### PR DESCRIPTION
## Summary
- Ensure frontend always appends a consistent auth token when opening WebSocket connections
- Start ping monitoring only after server handshake completes to avoid premature messages
- Document default dev token in env example

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a71b624be083248892856be4194cf9