### PR TITLE
Handle instant WebSocket open events to avoid handshake race

### DIFF
--- a/voice-assistant-apps/shared/core/OptimizedAudioStreamer.js
+++ b/voice-assistant-apps/shared/core/OptimizedAudioStreamer.js
@@ -141,7 +141,7 @@ class OptimizedAudioStreamer {
                 this.websocket = new WebSocket(wsUrl);
 
                 // Expect handshake: send {op:"hello", version, stream_id, device}
-                this.websocket.onopen = () => {
+                const handleOpen = () => {
                     try {
                         this.metrics.connection.connected = true;
                         this.metrics.connection.reconnectAttempts = 0;
@@ -170,6 +170,13 @@ class OptimizedAudioStreamer {
                     }
                     resolve();
                 };
+
+                this.websocket.onopen = handleOpen;
+                // In very fast connections the `open` event may fire before the
+                // handler is attached. Handle that case explicitly.
+                if (this.websocket.readyState === WebSocket.OPEN) {
+                    handleOpen();
+                }
 
                 this.websocket.onmessage = (event) => {
                     this.handleWebSocketMessage(event);

--- a/voice-assistant-apps/shared/core/VoiceAssistantCore.js
+++ b/voice-assistant-apps/shared/core/VoiceAssistantCore.js
@@ -264,7 +264,7 @@ class VoiceAssistantCore {
       this.ws = new WebSocket(wsUrl);
       this.ws.binaryType = 'arraybuffer';
 
-      this.ws.onopen = () => {
+      const handleOpen = () => {
         try {
           console.log('✅ WebSocket connected');
 
@@ -284,6 +284,13 @@ class VoiceAssistantCore {
           console.warn('Failed to complete WebSocket handshake', e);
         }
       };
+
+      this.ws.onopen = handleOpen;
+      // It's possible for extremely fast connections to reach OPEN before the
+      // onopen handler is registered. Trigger manually in that case.
+      if (this.ws.readyState === WebSocket.OPEN) {
+        handleOpen();
+      }
 
       this.ws.onmessage = (event) => {
         this.handleWebSocketMessage(event);


### PR DESCRIPTION
## Summary
- Ensure WebSocket `open` handlers execute even when the connection is already open in `OptimizedAudioStreamer` and `VoiceAssistantCore`
- Prevents missing handshake packets that caused timeouts or unexpected messages

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a71fee53c883248b8b53b41a8b1a3e