### PR TITLE
Refine desktop GUI layout and settings

### DIFF
--- a/gui/app.js
+++ b/gui/app.js
@@ -118,8 +118,7 @@ class VoiceAssistantGUI {
             if (success) {
                 console.log('✅ Voice Assistant initialized successfully');
                 this.showNotification('success', 'System Ready', 'Voice Assistant ready');
-                this.updateStatus('connected', '✅ Verbunden mit optimiertem Server');
-                
+
                 // Start performance monitoring if enabled
                 if (this.settings.showPerformanceMetrics) {
                     this.startPerformanceMonitoring();
@@ -137,7 +136,6 @@ class VoiceAssistantGUI {
         } catch (error) {
             console.error('❌ GUI initialization failed:', error);
             this.showNotification('error', 'Initialization Failed', error.message);
-            this.updateStatus('error', '❌ Verbindungsfehler');
         }
     }
 
@@ -445,19 +443,6 @@ class VoiceAssistantGUI {
         if (this.recordingTimer) {
             clearInterval(this.recordingTimer);
             this.recordingTimer = null;
-        }
-    }
-
-    updateStatus(type, message) {
-        const statusDot = document.getElementById('statusDot');
-        const statusText = document.getElementById('statusText');
-        
-        if (statusDot) {
-            statusDot.className = `status-dot ${type}`;
-        }
-        
-        if (statusText) {
-            statusText.textContent = message;
         }
     }
 

--- a/gui/index.html
+++ b/gui/index.html
@@ -211,7 +211,7 @@
       display: flex;
       flex-direction: column;
       padding: var(--spacing-lg);
-      padding-bottom: 120px; /* Space for bottom controls */
+      margin-bottom: 120px; /* Space for bottom controls */
       overflow-y: auto;
       gap: var(--spacing-lg);
     }
@@ -378,7 +378,7 @@
       border-radius: 24px;
       padding: var(--spacing-xl);
       flex: 1;
-      min-height: 200px;
+      min-height: 0;
       position: relative;
       display: flex;
       align-items: center;
@@ -394,6 +394,9 @@
       word-wrap: break-word;
       position: relative;
       z-index: 2;
+      width: 100%;
+      height: 100%;
+      overflow-y: auto;
     }
 
     .response-empty {
@@ -408,8 +411,8 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      width: 300px;
-      height: 300px;
+      width: 600px;
+      height: 600px;
       opacity: 0;
       transition: opacity 0.3s ease;
       pointer-events: none;
@@ -426,20 +429,20 @@
       width: 100%;
       height: 100%;
       border-radius: 50%;
-      background: radial-gradient(circle, var(--primary-color) 0%, rgba(99, 102, 241, 0) 70%);
-      filter: blur(10px);
+      background: radial-gradient(circle, var(--primary-color) 0%, rgba(99, 102, 241, 0.4) 60%, rgba(99, 102, 241, 0) 100%);
+      filter: blur(20px);
       animation: processingWave 2s ease-in-out infinite;
     }
 
     .processing-circle:nth-child(2) {
       animation-delay: 0.7s;
-      background: radial-gradient(circle, var(--secondary-color) 0%, rgba(16, 185, 129, 0) 70%);
+      background: radial-gradient(circle, var(--secondary-color) 0%, rgba(16, 185, 129, 0.4) 60%, rgba(16, 185, 129, 0) 100%);
       transform: scale(0.8);
     }
 
     .processing-circle:nth-child(3) {
       animation-delay: 1.4s;
-      background: radial-gradient(circle, var(--accent-color) 0%, rgba(245, 158, 11, 0) 70%);
+      background: radial-gradient(circle, var(--accent-color) 0%, rgba(245, 158, 11, 0.4) 60%, rgba(245, 158, 11, 0) 100%);
       transform: scale(0.6);
     }
 
@@ -639,7 +642,7 @@
       background: var(--bg-secondary);
       padding: var(--spacing-xl);
       border-radius: 16px;
-      min-width: 300px;
+      width: 400px;
       max-width: 90%;
       color: var(--text-primary);
     }
@@ -652,7 +655,7 @@
     }
 
     .settings-row label {
-      flex: 0 0 140px;
+      flex: 0 0 160px;
     }
 
     .settings-row input,


### PR DESCRIPTION
## Summary
- Remove unused status handling from the GUI script.
- Stretch and scroll the answer area so it fills remaining space between header and controls.
- Double processing animation size with a softer radial fade.
- Give the settings dialog a fixed width and wider label column for clearer configuration.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a736a3da108324a7fa582cf3d8021b