### PR TITLE
Handle LM Studio models in backend and GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,12 +357,19 @@ const config = {
   flowise: {
     url: 'http://odroid-gateway.headscale:3000'
   },
-  
+
   n8n: {
-    url: 'http://odroid-gateway.headscale:5678'  
+    url: 'http://odroid-gateway.headscale:5678'
   }
 };
 ```
+
+### Lokale LLMs (LM Studio)
+
+- LM Studio starten und ein Modell laden
+- In `.env` `LLM_API_BASE` setzen, z. B. `http://localhost:1234/v1`
+- Der Backend-Server ruft beim Start `GET /models` ab und wählt das erste Modell
+- Die Web-GUI zeigt alle Modelle in einem Auswahlfeld
 
 ## 🧠 Intent-Routing Logik
 

--- a/backend/ws-server/ws-server.py
+++ b/backend/ws-server/ws-server.py
@@ -407,9 +407,9 @@ class AudioStreamManager:
                     if resp.status == 200:
                         data = await resp.json()
                         models = [m.get("id") for m in data.get("data", []) if m.get("id")]
-                        if models:
-                            self.llm_models = models
-                            self.current_llm_model = self.current_llm_model or models[0]
+                        self.llm_models = models
+                        if self.current_llm_model not in models:
+                            self.current_llm_model = models[0] if models else None
         except Exception:
             logger.warning("Could not fetch LLM models from %s", url)
         

--- a/gui/index.html
+++ b/gui/index.html
@@ -1403,6 +1403,14 @@
       });
       const saved = localStorage.getItem('llmModel');
       select.value = saved && models.includes(saved) ? saved : (current || models[0] || '');
+      if (models.length === 0) {
+        const opt = document.createElement('option');
+        opt.value = '';
+        opt.textContent = '(kein Modell)';
+        select.appendChild(opt);
+        select.value = '';
+      }
+      select.disabled = models.length <= 1;
     }
 
     function setupPerformanceMonitoring() {


### PR DESCRIPTION
## Summary
- keep track of available LM Studio models and reset current selection when none are loaded
- disable LLM model dropdown when less than two models are available and show placeholder when none
- document LM Studio setup and configuration in README

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a73b44fcac8324a818d34f892984ca