### PR TITLE
Ensure desktop window appears after GUI load

### DIFF
--- a/voice-assistant-apps/desktop/src/main.js
+++ b/voice-assistant-apps/desktop/src/main.js
@@ -159,12 +159,14 @@ function createMainWindow() {
     log.error(`GUI did-fail-load: ${code} ${desc} @ ${theUrl}`);
     dialog.showErrorBox('GUI-Fehler', `Konnte GUI nicht laden:\n${desc} (Code ${code})`);
   });
-  mainWindow.webContents.on('did-finish-load', () => log.info('GUI did-finish-load'));
-
-  mainWindow.once('ready-to-show', () => {
+  const showWindow = () => {
+    if (!mainWindow) return;
+    log.info('GUI did-finish-load');
     try { mainWindow.show(); } catch {}
     if (isDev) mainWindow.webContents.openDevTools();
-  });
+  };
+  mainWindow.webContents.once('did-finish-load', showWindow);
+  mainWindow.once('ready-to-show', showWindow);
 
   mainWindow.on('closed', () => { mainWindow = null; });
 


### PR DESCRIPTION
## Summary
- Show Electron desktop window once GUI content finishes loading
- Keep devtools behavior by reusing the same handler for `ready-to-show`

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check src/main.js`
- `./run_tests.sh` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68a73f4e0cc083249b40636fa62b730f