### PR TITLE
Implement frontend settings modal with theme and engine switching

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -1131,6 +1131,24 @@
         clearTimeout(longPressTimer);
       });
 
+      // Theme toggle
+      const themeToggle = document.getElementById('themeToggle');
+      if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+          const isLight = document.documentElement.classList.toggle('light-mode');
+          localStorage.setItem('theme', isLight ? 'light' : 'dark');
+          themeToggle.textContent = isLight ? '🌙' : '☀️';
+        });
+
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'light') {
+          document.documentElement.classList.add('light-mode');
+          themeToggle.textContent = '🌙';
+        } else {
+          themeToggle.textContent = '☀️';
+        }
+      }
+
       // Settings button
       document.getElementById('settingsBtn').addEventListener('click', () => {
         showSettings();
@@ -1360,6 +1378,9 @@
       document.getElementById('sttModel').value = localStorage.getItem('sttModel') || 'Faster-Whisper';
       document.getElementById('ttsEngine').value = localStorage.getItem('ttsEngine') || 'Zonos';
       document.getElementById('llmModel').value = localStorage.getItem('llmModel') || '';
+      if (voiceAssistant) {
+        voiceAssistant.sendMessage({ type: 'get_llm_models' });
+      }
       modal.classList.add('open');
     }
 
@@ -1383,6 +1404,12 @@
       localStorage.setItem('ttsEngine', tts);
       localStorage.setItem('llmModel', llm);
 
+      if (stt) {
+        voiceAssistant.sendMessage({ type: 'switch_stt_model', model: stt });
+      }
+      if (tts) {
+        voiceAssistant.sendMessage({ type: 'switch_tts_engine', engine: tts });
+      }
       if (llm) {
         voiceAssistant.sendMessage({ type: 'switch_llm_model', model: llm });
       }


### PR DESCRIPTION
## Summary
- enable gear button to open full settings modal with network, STT, TTS and LLM options
- add light/dark theme toggle persistence
- send backend messages when switching STT, TTS or LLM models

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a7484d15ac8324a656f589216ccf1f