### PR TITLE
Expose loaded LLM models

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -1,0 +1,24 @@
+# Upgrade Notes
+
+## LLM Model Listings
+- WebSocket messages `get_llm_models` and `switch_llm_model` now expose
+  separate lists for available and loaded models.
+- Backend tracks the chosen LLM model and clears chat history when switching.
+
+## Migration
+- Clients should expect `llm_models` responses in the form:
+  ```json
+  {
+    "type": "llm_models",
+    "available": ["model-a", "model-b"],
+    "loaded": ["model-a"],
+    "current": "model-a"
+  }
+  ```
+- When selecting a new model send:
+  ```json
+  {
+    "type": "switch_llm_model",
+    "model": "model-b"
+  }
+  ```


### PR DESCRIPTION
## Summary
- include loaded information when listing LLM models
- relay available and loaded model lists to clients and allow switching
- add upgrade notes for LLM model switching

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a74fe199b48324a949fa5e8e92ae1a