### PR TITLE
sprint-3: add binary audio frame parser

### DIFF
--- a/tests/smoke/binary_frame_roundtrip.py
+++ b/tests/smoke/binary_frame_roundtrip.py
@@ -1,0 +1,21 @@
+from ws_server.protocol.binary_v2 import build_audio_frame, parse_audio_frame
+
+
+def test_roundtrip_parsing():
+    audio = b"\x00\x01\x02"
+    frame_bytes = build_audio_frame("stream", 5, 1234.5, audio)
+    frame = parse_audio_frame(frame_bytes)
+    assert frame.stream_id == "stream"
+    assert frame.sequence == 5
+    assert frame.timestamp == 1234.5
+    assert frame.audio_data == audio
+
+
+def test_too_short_frame():
+    short = b"\x00"  # clearly too short
+    try:
+        parse_audio_frame(short)
+    except ValueError as exc:
+        assert "too short" in str(exc)
+    else:
+        raise AssertionError("parse_audio_frame did not raise ValueError")


### PR DESCRIPTION
## Summary
- add standalone binary audio frame builder and parser
- wire handler to use parser and expose strict errors
- test roundtrip and error handling

## Testing
- `python -m pytest tests/smoke/binary_frame_roundtrip.py -q`
- `ruff check ws_server/protocol/binary_v2.py tests/smoke/binary_frame_roundtrip.py`
- `python -m pytest -q` *(fails: FLOWISE_URL or FLOWISE_ID not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a85f3dc34c8324a527c412e400d9f1