### PR TITLE
sprint-4: add LRU caching and timeouts to staged TTS

### DIFF
--- a/backend/ws-server/staged_tts/staged_processor.py
+++ b/backend/ws-server/staged_tts/staged_processor.py
@@ -7,8 +7,10 @@ import time
 import uuid
 import base64
 import logging
-from typing import List, Dict, Any, Optional, Tuple
+import hashlib
+from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
+from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +37,7 @@ class StagedTTSConfig:
     chunk_timeout_seconds: int = 10
     max_chunks: int = 3
     enable_caching: bool = True
+    cache_size: int = 256
 
 
 class StagedTTSProcessor:
@@ -49,7 +52,8 @@ class StagedTTSProcessor:
     def __init__(self, tts_manager, config: StagedTTSConfig = None):
         self.tts_manager = tts_manager
         self.config = config or StagedTTSConfig()
-        self._cache: Dict[str, bytes] = {}
+        # LRU Cache for synthesized audio
+        self._cache: "OrderedDict[str, bytes]" = OrderedDict()
         
     async def process_staged_tts(self, text: str) -> List[TTSChunk]:
         """
@@ -79,7 +83,6 @@ class StagedTTSProcessor:
         
         # Tasks für parallele Verarbeitung erstellen
         tasks = []
-        result_chunks = []
         
         # Stage A: Piper Intro (sofort starten)
         if intro_text:
@@ -107,31 +110,13 @@ class StagedTTSProcessor:
             )
             tasks.append(zonos_task)
         
-        # Warte auf alle Tasks mit Timeout
-        try:
-            completed_chunks = await asyncio.wait_for(
-                asyncio.gather(*tasks, return_exceptions=True),
-                timeout=self.config.chunk_timeout_seconds * len(tasks)
-            )
-            
-            # Sortiere Chunks nach Index
-            valid_chunks = [chunk for chunk in completed_chunks 
-                          if isinstance(chunk, TTSChunk)]
-            valid_chunks.sort(key=lambda x: x.index)
-            
-            return valid_chunks
-            
-        except asyncio.TimeoutError:
-            logger.warning(f"Staged TTS timeout nach {self.config.chunk_timeout_seconds}s")
-            # Versuche wenigstens das Intro zurückzugeben
-            if tasks:
-                try:
-                    intro_result = await asyncio.wait_for(tasks[0], timeout=1.0)
-                    if isinstance(intro_result, TTSChunk):
-                        return [intro_result]
-                except asyncio.TimeoutError:
-                    pass
-            return []
+        completed_chunks = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Sortiere Chunks nach Index
+        valid_chunks = [chunk for chunk in completed_chunks if isinstance(chunk, TTSChunk)]
+        valid_chunks.sort(key=lambda x: x.index)
+
+        return valid_chunks
     
     async def _synthesize_chunk(self, text: str, engine: str, sequence_id: str, 
                                index: int, total: int) -> TTSChunk:
@@ -149,32 +134,50 @@ class StagedTTSProcessor:
             TTSChunk mit Ergebnis
         """
         try:
-            # Cache-Check
-            cache_key = f"{engine}:{hash(text)}"
+            # Cache key based on engine and text hash
+            cache_key = f"{engine}:{hashlib.sha256(text.encode('utf-8')).hexdigest()}"
             if self.config.enable_caching and cache_key in self._cache:
                 logger.debug(f"Cache hit für {engine} chunk {index}")
+                audio = self._cache.pop(cache_key)
+                self._cache[cache_key] = audio
                 return TTSChunk(
                     sequence_id=sequence_id,
                     index=index,
                     total=total,
                     engine=engine,
                     text=text,
-                    audio_data=self._cache[cache_key],
+                    audio_data=audio,
                     success=True
                 )
-            
-            # TTS-Synthese
+
+            # TTS-Synthese mit Timeout
             start_time = time.time()
-            result = await self.tts_manager.synthesize(text, engine=engine)
+            try:
+                result = await asyncio.wait_for(
+                    self.tts_manager.synthesize(text, engine=engine),
+                    timeout=self.config.chunk_timeout_seconds
+                )
+            except asyncio.TimeoutError:
+                logger.warning(f"{engine.capitalize()} TTS Timeout für chunk {index}")
+                return TTSChunk(
+                    sequence_id=sequence_id,
+                    index=index,
+                    total=total,
+                    engine=engine,
+                    text=text,
+                    audio_data=None,
+                    success=False,
+                    error_message="timeout"
+                )
+
             processing_time = time.time() - start_time
-            
             logger.debug(f"{engine.capitalize()} TTS chunk {index}: {processing_time:.2f}s")
-            
+
             if result.success and result.audio_data:
-                # In Cache speichern
                 if self.config.enable_caching:
                     self._cache[cache_key] = result.audio_data
-                
+                    if len(self._cache) > self.config.cache_size:
+                        self._cache.popitem(last=False)
                 return TTSChunk(
                     sequence_id=sequence_id,
                     index=index,
@@ -184,18 +187,17 @@ class StagedTTSProcessor:
                     audio_data=result.audio_data,
                     success=True
                 )
-            else:
-                logger.warning(f"{engine.capitalize()} TTS fehlgeschlagen für chunk {index}: {result.error_message}")
-                return TTSChunk(
-                    sequence_id=sequence_id,
-                    index=index,
-                    total=total,
-                    engine=engine,
-                    text=text,
-                    audio_data=None,
-                    success=False,
-                    error_message=result.error_message
-                )
+            logger.warning(f"{engine.capitalize()} TTS fehlgeschlagen für chunk {index}: {result.error_message}")
+            return TTSChunk(
+                sequence_id=sequence_id,
+                index=index,
+                total=total,
+                engine=engine,
+                text=text,
+                audio_data=None,
+                success=False,
+                error_message=result.error_message
+            )
                 
         except Exception as e:
             logger.error(f"Fehler bei {engine} TTS chunk {index}: {e}")

--- a/tests/integration/staged_tts_flow.py
+++ b/tests/integration/staged_tts_flow.py
@@ -1,0 +1,45 @@
+import asyncio
+import time
+
+from pathlib import Path
+import sys
+
+# Ensure staged_tts package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "backend" / "ws-server"))
+
+from staged_tts.staged_processor import (
+    StagedTTSConfig,
+    StagedTTSProcessor,
+)
+
+
+class MockTTSManager:
+    async def synthesize(self, text, engine=None):
+        await asyncio.sleep(0.01 if engine == "piper" else 0.02)
+
+        class Result:
+            success = True
+            audio_data = b"mock"
+            engine_used = engine
+            error_message = None
+
+        return Result()
+
+
+def test_staged_tts_flow():
+    """Ensure staged TTS returns intro and main chunks with sequence end."""
+    processor = StagedTTSProcessor(MockTTSManager(), StagedTTSConfig())
+    start = time.time()
+    chunks = asyncio.run(
+        processor.process_staged_tts(
+            "Hallo Welt. Dies ist ein Test fuer das Staged TTS System."
+        )
+    )
+    duration = time.time() - start
+    assert duration < 1.0
+    assert chunks
+    assert chunks[0].engine == "piper"
+    messages = [processor.create_chunk_message(c) for c in chunks]
+    messages.append(processor.create_sequence_end_message(chunks[0].sequence_id))
+    assert messages[0]["type"] == "tts_chunk"
+    assert messages[-1]["type"] == "tts_sequence_end"

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -267,6 +267,7 @@ class StreamingConfig:
     staged_tts_chunk_timeout: int = int(os.getenv("STAGED_TTS_CHUNK_TIMEOUT", "10"))
     staged_tts_max_chunks: int = int(os.getenv("STAGED_TTS_MAX_CHUNKS", "3"))
     staged_tts_enable_caching: bool = os.getenv("STAGED_TTS_ENABLE_CACHING", "true").lower() == "true"
+    staged_tts_cache_size: int = int(os.getenv("STAGED_TTS_CACHE_SIZE", "256"))
     
     # VAD Configuration
     vad_enabled: bool = os.getenv("VAD_ENABLED", "false").lower() == "true"
@@ -932,7 +933,8 @@ class VoiceServer:
             max_intro_length=config.staged_tts_max_intro_length,
             chunk_timeout_seconds=config.staged_tts_chunk_timeout,
             max_chunks=config.staged_tts_max_chunks,
-            enable_caching=config.staged_tts_enable_caching
+            enable_caching=config.staged_tts_enable_caching,
+            cache_size=config.staged_tts_cache_size
         )
         self.staged_tts = StagedTTSProcessor(self.tts_manager, staged_tts_config)
         logger.info(f"🎭 Staged TTS: {'enabled' if config.staged_tts_enabled else 'disabled'}")


### PR DESCRIPTION
## Summary
- add configurable cache size and per-chunk timeouts to staged TTS processor
- expose staged TTS cache size in server config and wiring
- add integration test covering staged TTS chunk/sequence events

## Testing
- `ruff check backend/ws-server/staged_tts/staged_processor.py tests/integration/staged_tts_flow.py`
- `ruff check ws_server/compat/legacy_ws_server.py` *(fails: Module level import not at top of file)*
- `python -m pytest tests/integration/staged_tts_flow.py -q`
- `python -m pytest tests/smoke/binary_frame_roundtrip.py -q`
- `python -m pytest -q` *(fails: ModuleNotFoundError: websockets, piper, requests, dotenv, jwt)*

------
https://chatgpt.com/codex/tasks/task_e_68a8627a58208324b89fd935348289de