### PR TITLE
sprint-5: unify metrics collector and http api

### DIFF
--- a/tests/smoke/http_metrics.py
+++ b/tests/smoke/http_metrics.py
@@ -1,0 +1,30 @@
+import asyncio
+
+import aiohttp
+from aiohttp import web
+
+from ws_server.metrics.http_api import create_app
+
+
+async def _run_checks() -> None:
+    app = create_app()
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"http://127.0.0.1:{port}/health") as resp:
+            assert resp.status == 200
+
+        async with session.get(f"http://127.0.0.1:{port}/metrics") as resp:
+            assert resp.status == 200
+            assert resp.headers["Content-Type"].startswith("text/plain")
+
+    await runner.cleanup()
+
+
+def test_http_metrics_smoke() -> None:
+    asyncio.run(_run_checks())
+

--- a/ws_server/cli.py
+++ b/ws_server/cli.py
@@ -1,17 +1,32 @@
 #!/usr/bin/env python3
-import asyncio, os, logging
+import asyncio
+import logging
+import os
+
 from ws_server.transport.server import VoiceServer
+from ws_server.metrics.collector import collector
+from ws_server.metrics.http_api import start_http_server
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
 async def main():
     server = VoiceServer()
     await server.initialize()
-    host = os.getenv("WS_HOST","127.0.0.1")
-    port = int(os.getenv("WS_PORT","48231"))
+
+    host = os.getenv("WS_HOST", "127.0.0.1")
+    port = int(os.getenv("WS_PORT", "48231"))
+    metrics_port = int(os.getenv("METRICS_PORT", "48232"))
+
+    collector.start()
+    await start_http_server(metrics_port)
+
     import websockets
-    async with websockets.serve(server.handle_websocket, host, port, ping_interval=20, ping_timeout=10):
+
+    async with websockets.serve(
+        server.handle_websocket, host, port, ping_interval=20, ping_timeout=10
+    ):
         logging.info("Unified WS-Server listening on ws://%s:%s", host, port)
+        logging.info("📊 Metrics at :%s", metrics_port)
         await asyncio.Future()
 
 if __name__ == "__main__":

--- a/ws_server/metrics/collector.py
+++ b/ws_server/metrics/collector.py
@@ -1,472 +1,111 @@
-"""
-Performance Metrics API for Voice Assistant
-Provides real-time monitoring and diagnostics for binary audio pipeline
+"""Minimal metrics collector using Prometheus client.
+
+This module exposes a singleton :data:`collector` that other parts of the
+server can use to record counters and gauges.  The collector keeps track of
+active connections, message counts and basic latency histograms.  It is
+intentionally lightweight to avoid blocking the event loop.
 """
 
+from __future__ import annotations
+
 import asyncio
-import json
-import time
-import psutil
-import threading
-from typing import Dict, Any, List, Optional
-from dataclasses import dataclass, asdict
-from collections import deque, defaultdict
-import statistics
 import logging
+from typing import Optional
+
+try:  # pragma: no-cover - optional dependency
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - psutil may not be installed in tests
+    psutil = None  # type: ignore
+
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+)
 
 logger = logging.getLogger(__name__)
 
-@dataclass
-class LatencyMetric:
-    """Individual latency measurement"""
-    timestamp: float
-    operation: str  # 'stt', 'tts', 'audio_processing', 'binary_decode'
-    latency_ms: float
-    stream_id: str = ""
-    additional_info: Dict[str, Any] = None
-
-@dataclass
-class AudioQualityMetric:
-    """Audio quality measurement"""
-    timestamp: float
-    stream_id: str
-    sample_rate: int
-    bit_depth: int
-    signal_to_noise_ratio: float = 0.0
-    peak_amplitude: float = 0.0
-    rms_level: float = 0.0
-    frequency_response: Dict[str, float] = None
-
-@dataclass
-class ConnectionMetric:
-    """Connection quality measurement"""
-    timestamp: float
-    connection_id: str
-    latency_ms: float
-    packet_loss: float = 0.0
-    bandwidth_usage: int = 0  # bytes per second
-    connection_type: str = "websocket"
 
 class MetricsCollector:
-    """Collects and aggregates performance metrics"""
-    
-    def __init__(self, max_history_size: int = 1000):
-        self.max_history_size = max_history_size
-        
-        # Metric storage
-        self.latency_metrics: deque = deque(maxlen=max_history_size)
-        self.audio_quality_metrics: deque = deque(maxlen=max_history_size)
-        self.connection_metrics: deque = deque(maxlen=max_history_size)
-        
-        # Real-time aggregations
-        self.current_stats = {
-            'latency': defaultdict(list),
-            'throughput': defaultdict(int),
-            'error_rates': defaultdict(int),
-            'system_resources': {}
-        }
-        
-        # Performance tracking
-        self.operation_timers: Dict[str, float] = {}
-        self.active_streams: Dict[str, Dict] = {}
-        
-        # Start background aggregation
-        self.aggregation_thread = threading.Thread(target=self._background_aggregation, daemon=True)
-        self.aggregation_thread.start()
-        
-        logger.info("MetricsCollector initialized")
-    
-    def start_operation_timer(self, operation_id: str, operation_type: str, stream_id: str = ""):
-        """Start timing an operation"""
-        timer_key = f"{operation_id}_{operation_type}"
-        self.operation_timers[timer_key] = {
-            'start_time': time.time(),
-            'operation_type': operation_type,
-            'stream_id': stream_id
-        }
-    
-    def end_operation_timer(self, operation_id: str, operation_type: str, additional_info: Dict = None):
-        """End timing an operation and record latency"""
-        timer_key = f"{operation_id}_{operation_type}"
-        
-        if timer_key in self.operation_timers:
-            timer_info = self.operation_timers.pop(timer_key)
-            latency_ms = (time.time() - timer_info['start_time']) * 1000
-            
-            metric = LatencyMetric(
-                timestamp=time.time(),
-                operation=operation_type,
-                latency_ms=latency_ms,
-                stream_id=timer_info['stream_id'],
-                additional_info=additional_info or {}
-            )
-            
-            self.latency_metrics.append(metric)
-            self.current_stats['latency'][operation_type].append(latency_ms)
-            
-            # Keep only recent measurements for real-time stats
-            if len(self.current_stats['latency'][operation_type]) > 100:
-                self.current_stats['latency'][operation_type] = \
-                    self.current_stats['latency'][operation_type][-50:]
-    
-    def record_audio_quality(self, stream_id: str, sample_rate: int, audio_data: bytes, 
-                           additional_metrics: Dict = None):
-        """Record audio quality metrics"""
-        try:
-            import numpy as np
-            
-            # Convert audio data to numpy array for analysis
-            audio_array = np.frombuffer(audio_data, dtype=np.int16)
-            
-            # Calculate basic audio metrics
-            rms_level = float(np.sqrt(np.mean(audio_array.astype(np.float32) ** 2)))
-            peak_amplitude = float(np.max(np.abs(audio_array)))
-            
-            # Estimate SNR (simplified)
-            signal_power = np.mean(audio_array.astype(np.float32) ** 2)
-            noise_floor = 0.01 * signal_power  # Simplified estimate
-            snr = 10 * np.log10(signal_power / max(noise_floor, 1e-10))
-            
-            metric = AudioQualityMetric(
-                timestamp=time.time(),
-                stream_id=stream_id,
-                sample_rate=sample_rate,
-                bit_depth=16,  # Assuming 16-bit
-                signal_to_noise_ratio=float(snr),
-                peak_amplitude=peak_amplitude,
-                rms_level=rms_level,
-                frequency_response=additional_metrics or {}
-            )
-            
-            self.audio_quality_metrics.append(metric)
-            
-        except Exception as e:
-            logger.warning(f"Error calculating audio quality metrics: {e}")
-    
-    def record_connection_metric(self, connection_id: str, latency_ms: float, 
-                               bandwidth_usage: int = 0, packet_loss: float = 0.0):
-        """Record connection quality metrics"""
-        metric = ConnectionMetric(
-            timestamp=time.time(),
-            connection_id=connection_id,
-            latency_ms=latency_ms,
-            packet_loss=packet_loss,
-            bandwidth_usage=bandwidth_usage
+    """Central metrics registry used by the WebSocket server."""
+
+    def __init__(self) -> None:
+        self.registry = CollectorRegistry()
+
+        # Gauges
+        self.active_connections = Gauge(
+            "ws_active_connections",
+            "Number of active WebSocket connections",
+            registry=self.registry,
         )
-        
-        self.connection_metrics.append(metric)
-    
-    def update_throughput(self, operation_type: str, count: int = 1):
-        """Update throughput counter"""
-        self.current_stats['throughput'][operation_type] += count
-    
-    def record_error(self, error_type: str):
-        """Record error occurrence"""
-        self.current_stats['error_rates'][error_type] += 1
-    
-    def get_real_time_metrics(self) -> Dict[str, Any]:
-        """Get current real-time metrics"""
-        current_time = time.time()
-        
-        # Calculate latency statistics
-        latency_stats = {}
-        for operation, latencies in self.current_stats['latency'].items():
-            if latencies:
-                latency_stats[operation] = {
-                    'avg_ms': statistics.mean(latencies),
-                    'min_ms': min(latencies),
-                    'max_ms': max(latencies),
-                    'p95_ms': statistics.quantiles(latencies, n=20)[18] if len(latencies) >= 20 else max(latencies),
-                    'p99_ms': statistics.quantiles(latencies, n=100)[98] if len(latencies) >= 100 else max(latencies),
-                    'count': len(latencies)
-                }
-        
-        # System resource metrics
-        system_metrics = self._get_system_metrics()
-        
-        # Audio quality statistics
-        audio_quality_stats = self._get_audio_quality_stats()
-        
-        # Connection statistics
-        connection_stats = self._get_connection_stats()
-        
-        return {
-            'timestamp': current_time,
-            'latency': latency_stats,
-            'system': system_metrics,
-            'audio_quality': audio_quality_stats,
-            'connections': connection_stats,
-            'throughput': dict(self.current_stats['throughput']),
-            'error_rates': dict(self.current_stats['error_rates']),
-            'active_streams': len(self.active_streams)
-        }
-    
-    def get_historical_metrics(self, time_range_seconds: int = 300) -> Dict[str, Any]:
-        """Get historical metrics for specified time range"""
-        cutoff_time = time.time() - time_range_seconds
-        
-        # Filter metrics by time range
-        recent_latency = [m for m in self.latency_metrics if m.timestamp >= cutoff_time]
-        recent_audio = [m for m in self.audio_quality_metrics if m.timestamp >= cutoff_time]
-        recent_connections = [m for m in self.connection_metrics if m.timestamp >= cutoff_time]
-        
-        return {
-            'time_range_seconds': time_range_seconds,
-            'latency_metrics': [asdict(m) for m in recent_latency],
-            'audio_quality_metrics': [asdict(m) for m in recent_audio],
-            'connection_metrics': [asdict(m) for m in recent_connections]
-        }
-    
-    def _get_system_metrics(self) -> Dict[str, Any]:
-        """Get current system resource metrics"""
-        try:
-            cpu_percent = psutil.cpu_percent(interval=None)
-            memory = psutil.virtual_memory()
-            disk = psutil.disk_usage('/')
-            
-            # Network I/O
-            network = psutil.net_io_counters()
-            
-            return {
-                'cpu_percent': cpu_percent,
-                'memory_percent': memory.percent,
-                'memory_available_mb': memory.available // (1024 * 1024),
-                'disk_usage_percent': disk.percent,
-                'disk_free_gb': disk.free // (1024 * 1024 * 1024),
-                'network_bytes_sent': network.bytes_sent,
-                'network_bytes_recv': network.bytes_recv,
-                'timestamp': time.time()
-            }
-        except Exception as e:
-            logger.warning(f"Error getting system metrics: {e}")
-            return {}
-    
-    def _get_audio_quality_stats(self) -> Dict[str, Any]:
-        """Get aggregated audio quality statistics"""
-        if not self.audio_quality_metrics:
-            return {}
-        
-        recent_metrics = list(self.audio_quality_metrics)[-50:]  # Last 50 measurements
-        
-        snr_values = [m.signal_to_noise_ratio for m in recent_metrics if m.signal_to_noise_ratio > 0]
-        rms_values = [m.rms_level for m in recent_metrics if m.rms_level > 0]
-        
-        stats = {}
-        if snr_values:
-            stats['avg_snr_db'] = statistics.mean(snr_values)
-            stats['min_snr_db'] = min(snr_values)
-        
-        if rms_values:
-            stats['avg_rms_level'] = statistics.mean(rms_values)
-            stats['peak_rms_level'] = max(rms_values)
-        
-        stats['sample_count'] = len(recent_metrics)
-        return stats
-    
-    def _get_connection_stats(self) -> Dict[str, Any]:
-        """Get connection quality statistics"""
-        if not self.connection_metrics:
-            return {}
-        
-        recent_metrics = list(self.connection_metrics)[-50:]
-        
-        latencies = [m.latency_ms for m in recent_metrics]
-        bandwidths = [m.bandwidth_usage for m in recent_metrics if m.bandwidth_usage > 0]
-        
-        stats = {
-            'connection_count': len(recent_metrics),
-            'avg_latency_ms': statistics.mean(latencies) if latencies else 0,
-            'max_latency_ms': max(latencies) if latencies else 0
-        }
-        
-        if bandwidths:
-            stats['avg_bandwidth_bps'] = statistics.mean(bandwidths)
-            stats['peak_bandwidth_bps'] = max(bandwidths)
-        
-        return stats
-    
-    def _background_aggregation(self):
-        """Background thread for metric aggregation and cleanup"""
+        self.cpu_percent = Gauge(
+            "system_cpu_percent",
+            "System wide CPU utilisation in percent",
+            registry=self.registry,
+        )
+
+        # Counters
+        self.messages_total = Counter(
+            "ws_messages_total",
+            "Count of received WebSocket messages",
+            ["protocol"],
+            registry=self.registry,
+        )
+        self.errors_total = Counter(
+            "ws_errors_total",
+            "Number of error responses sent to clients",
+            ["type"],
+            registry=self.registry,
+        )
+        self.tts_cache_hits = Counter(
+            "tts_cache_hits_total",
+            "Number of TTS cache hits",
+            registry=self.registry,
+        )
+        self.tts_cache_misses = Counter(
+            "tts_cache_misses_total",
+            "Number of TTS cache misses",
+            registry=self.registry,
+        )
+
+        # Histograms for latency measurements
+        self.stt_latency = Histogram(
+            "stt_latency_seconds",
+            "Latency of STT processing in seconds",
+            registry=self.registry,
+            buckets=(0.1, 0.5, 1, 2, 5, 10),
+        )
+        self.tts_latency = Histogram(
+            "tts_latency_seconds",
+            "Latency of TTS synthesis in seconds",
+            registry=self.registry,
+            buckets=(0.1, 0.5, 1, 2, 5, 10),
+        )
+
+        self._system_task: Optional[asyncio.Task] = None
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start background tasks for system metrics collection."""
+
+        if self._system_task is None:
+            loop = asyncio.get_event_loop()
+            self._system_task = loop.create_task(self._update_system_metrics())
+
+    async def _update_system_metrics(self) -> None:
         while True:
             try:
-                time.sleep(30)  # Run every 30 seconds
-                
-                # Clear old real-time stats
-                current_time = time.time()
-                
-                # Reset throughput counters every minute
-                if int(current_time) % 60 == 0:
-                    self.current_stats['throughput'].clear()
-                
-                # Clear old latency measurements
-                for operation_type in list(self.current_stats['latency'].keys()):
-                    if len(self.current_stats['latency'][operation_type]) > 200:
-                        self.current_stats['latency'][operation_type] = \
-                            self.current_stats['latency'][operation_type][-100:]
-                
-                logger.debug("Metrics aggregation completed")
-                
-            except Exception as e:
-                logger.error(f"Error in background aggregation: {e}")
+                if psutil is not None:  # pragma: no cover - not critical in tests
+                    self.cpu_percent.set(psutil.cpu_percent())
+            except Exception as exc:  # pragma: no cover - diagnostic only
+                logger.debug("cpu metrics failed: %s", exc)
+            await asyncio.sleep(5)
 
-class MetricsAPI:
-    """HTTP API for accessing metrics"""
-    
-    def __init__(self, metrics_collector: MetricsCollector):
-        self.metrics_collector = metrics_collector
-    
-    async def handle_metrics_request(self, request_path: str, query_params: Dict[str, str]) -> Dict[str, Any]:
-        """Handle metrics API requests"""
-        try:
-            if request_path == '/api/metrics/realtime':
-                return {
-                    'status': 'success',
-                    'data': self.metrics_collector.get_real_time_metrics()
-                }
-            
-            elif request_path == '/api/metrics/historical':
-                time_range = int(query_params.get('time_range', '300'))
-                return {
-                    'status': 'success',
-                    'data': self.metrics_collector.get_historical_metrics(time_range)
-                }
-            
-            elif request_path == '/api/metrics/system':
-                return {
-                    'status': 'success',
-                    'data': self.metrics_collector._get_system_metrics()
-                }
-            
-            elif request_path == '/api/metrics/audio':
-                return {
-                    'status': 'success',
-                    'data': self.metrics_collector._get_audio_quality_stats()
-                }
-            
-            else:
-                return {
-                    'status': 'error',
-                    'message': f'Unknown metrics endpoint: {request_path}'
-                }
-                
-        except Exception as e:
-            logger.error(f"Error handling metrics request: {e}")
-            return {
-                'status': 'error',
-                'message': f'Internal server error: {str(e)}'
-            }
 
-# Integration with WebSocket server
-class MetricsIntegratedWebSocketServer:
-    """WebSocket server with integrated metrics collection"""
-    
-    def __init__(self, enhanced_server):
-        self.enhanced_server = enhanced_server
-        self.metrics_collector = MetricsCollector()
-        self.metrics_api = MetricsAPI(self.metrics_collector)
-        
-        # Integrate metrics into existing handlers
-        self._integrate_metrics()
-    
-    def _integrate_metrics(self):
-        """Integrate metrics collection into existing server"""
-        # Wrap existing methods with metrics collection
-        original_handle_binary = self.enhanced_server.binary_router.binary_handler.handle_binary_message
-        original_handle_audio = self.enhanced_server.binary_router.message_handler.handle_audio_message
-        
-        async def instrumented_binary_handler(websocket, data, stt_processor, message_handler):
-            # Start timer
-            operation_id = f"binary_{time.time()}"
-            self.metrics_collector.start_operation_timer(operation_id, "binary_decode")
-            
-            try:
-                result = await original_handle_binary(websocket, data, stt_processor, message_handler)
-                
-                # Record metrics
-                self.metrics_collector.update_throughput("binary_messages")
-                if len(data) > 0:
-                    # Record connection metrics
-                    connection_id = f"{websocket.remote_address[0]}:{websocket.remote_address[1]}"
-                    self.metrics_collector.record_connection_metric(
-                        connection_id, 
-                        0,  # Would need actual latency measurement
-                        len(data)
-                    )
-                
-                return result
-                
-            except Exception as e:
-                self.metrics_collector.record_error("binary_processing")
-                raise
-            finally:
-                self.metrics_collector.end_operation_timer(operation_id, "binary_decode")
-        
-        async def instrumented_audio_handler(websocket, data):
-            operation_id = f"audio_{time.time()}"
-            self.metrics_collector.start_operation_timer(operation_id, "stt")
-            
-            try:
-                result = await original_handle_audio(websocket, data)
-                self.metrics_collector.update_throughput("audio_processed")
-                return result
-            except Exception as e:
-                self.metrics_collector.record_error("stt_processing")
-                raise
-            finally:
-                self.metrics_collector.end_operation_timer(operation_id, "stt")
-        
-        # Replace methods with instrumented versions
-        self.enhanced_server.binary_router.binary_handler.handle_binary_message = instrumented_binary_handler
-        self.enhanced_server.binary_router.message_handler.handle_audio_message = instrumented_audio_handler
-    
-    async def handle_metrics_websocket_request(self, websocket, message):
-        """Handle metrics request via WebSocket"""
-        try:
-            data = json.loads(message) if isinstance(message, str) else message
-            
-            if data.get('type') == 'get_metrics':
-                metrics_type = data.get('metrics_type', 'realtime')
-                
-                if metrics_type == 'realtime':
-                    metrics_data = self.metrics_collector.get_real_time_metrics()
-                elif metrics_type == 'historical':
-                    time_range = data.get('time_range', 300)
-                    metrics_data = self.metrics_collector.get_historical_metrics(time_range)
-                else:
-                    metrics_data = {'error': 'Unknown metrics type'}
-                
-                response = {
-                    'type': 'metrics_response',
-                    'request_id': data.get('request_id'),
-                    'timestamp': time.time(),
-                    'data': metrics_data
-                }
-                
-                await websocket.send(json.dumps(response))
-                
-        except Exception as e:
-            logger.error(f"Error handling metrics WebSocket request: {e}")
-    
-    def get_metrics_summary(self) -> Dict[str, Any]:
-        """Get comprehensive metrics summary"""
-        return {
-            'server_metrics': self.enhanced_server.get_server_metrics(),
-            'performance_metrics': self.metrics_collector.get_real_time_metrics(),
-            'collection_info': {
-                'total_latency_measurements': len(self.metrics_collector.latency_metrics),
-                'total_audio_quality_measurements': len(self.metrics_collector.audio_quality_metrics),
-                'total_connection_measurements': len(self.metrics_collector.connection_metrics)
-            }
-        }
+# Singleton instance used by the application
+collector = MetricsCollector()
 
-# Example usage
-if __name__ == "__main__":
-    # This would integrate with your existing server
-    collector = MetricsCollector()
-    
-    # Simulate some metrics
-    collector.start_operation_timer("test1", "stt", "stream_123")
-    time.sleep(0.1)
-    collector.end_operation_timer("test1", "stt")
-    
-    print("Real-time metrics:", json.dumps(collector.get_real_time_metrics(), indent=2))
+
+__all__ = ["collector", "MetricsCollector"]
+

--- a/ws_server/metrics/http_api.py
+++ b/ws_server/metrics/http_api.py
@@ -1,145 +1,59 @@
-#!/usr/bin/env python3
-"""
-🌐 HTTP API Server für Voice Assistant Metriken
-Ergänzt den WebSocket-Server um HTTP-Endpoints für Monitoring.
-Alle Hosts/Ports sind ENV-gesteuert (WS_HOST, WS_PORT, METRICS_PORT).
+"""HTTP endpoints for metrics and health checks.
+
+The module exposes :func:`create_app` used by tests and
+:func:`start_http_server` which launches an ``aiohttp`` web server in the
+background.  The ``/metrics`` endpoint returns Prometheus text format metrics
+and ``/health`` reports basic service status.
 """
 
-import asyncio
-import os
-import json
-import time
+from __future__ import annotations
+
 import logging
+import os
 from aiohttp import web
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
-from aiohttp import web
-
-@web.middleware
-async def cors_middleware(request, handler):
-    try:
-        resp = await handler(request)
-    except web.HTTPException as ex:
-        resp = ex
-    resp.headers['Access-Control-Allow-Origin'] = '*'
-    resp.headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS'
-    resp.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
-    return resp
+from .collector import collector
 
 logger = logging.getLogger(__name__)
 
-# ENV
-WS_HOST = os.getenv('WS_HOST', '127.0.0.1')
-WS_PORT = int(os.getenv('WS_PORT', '48231'))
-METRICS_PORT = int(os.getenv('METRICS_PORT', '48232'))
 
-# Für "0.0.0.0" Links trotzdem localhost zeigen
-def _display_host(h: str) -> str:
-    return '127.0.0.1' if h in ('0.0.0.0', '::') else h
-
-def _endpoints():
-    host_disp = _display_host(WS_HOST)
-    met_disp  = _display_host(WS_HOST)
-    return {
-        'websocket': f'ws://{host_disp}:{WS_PORT}',
-        'metrics':   f'http://{met_disp}:{METRICS_PORT}/metrics',
-        'health':    f'http://{met_disp}:{METRICS_PORT}/health'
-    }
-
-class MetricsAPI:
-    """HTTP API für Performance-Metriken"""
-    def __init__(self, voice_server):
-        self.voice_server = voice_server
-        self.app = web.Application()
-        self.setup_routes()
-
-    def setup_routes(self):
-        self.app.router.add_get('/metrics', self.get_metrics)
-        self.app.router.add_get('/health', self.health_check)
-        self.app.router.add_get('/status', self.status_handler)
-        self.app.router.add_options('/{path:.*}', self.handle_cors)
-        self.app.middlewares.append(cors_middleware)
-
-    async def handle_cors(self, request):
-        from aiohttp import web
-        return web.Response(headers={
-            'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type, Authorization'
-        })
+async def _metrics_handler(request: web.Request) -> web.StreamResponse:
+    data = generate_latest(collector.registry)
+    return web.Response(body=data, headers={"Content-Type": CONTENT_TYPE_LATEST})
 
 
-
-    async def get_metrics(self, request):
-        try:
-            stats = self.voice_server.get_stats()
-            metrics = {
-                **stats,
-                'server_time': time.time(),
-                'api_version': '2.1.0',
-                'endpoints': _endpoints()
-            }
-            import json
-            return web.json_response(metrics, dumps=lambda d: json.dumps(d, default=str))
-        except Exception as e:
-            logger.error(f"Metrics API error: {e}")
-            return web.json_response({'error': 'Internal server error'}, status=500)
-    def get_status(self):
-        """Interner Status für Boot‑Checks und /health."""
-        engines = []
-        default_engine = None
-        try:
-            tm = getattr(self, 'voice_server', None)
-            if tm and getattr(tm, 'tts_manager', None):
-                ttm = tm.tts_manager
-                engines = list(getattr(ttm, 'engines', {}).keys())
-                cur = getattr(ttm, 'get_current_engine', lambda: None)()
-                if cur is not None:
-                    default_engine = getattr(cur, 'value', str(cur))
-        except Exception:
-            pass
-        return {
-            'service': 'metrics',
-            'ok': True,
-            'engines': [str(e) for e in engines],
-            'default_engine': default_engine,
-        }
+async def _health_handler(request: web.Request) -> web.StreamResponse:
+    return web.json_response({"status": "green"})
 
 
-    async def status_handler(self, request):
-        from aiohttp import web
-        return web.json_response(self.get_status())
+def create_app() -> web.Application:
+    """Create an ``aiohttp`` application exposing metrics endpoints."""
+
+    app = web.Application()
+    app.router.add_get("/metrics", _metrics_handler)
+    app.router.add_get("/health", _health_handler)
+    return app
 
 
+async def start_http_server(port: int | None = None) -> web.AppRunner:
+    """Start the metrics HTTP server on ``port``.
 
+    Returns the underlying :class:`~aiohttp.web.AppRunner` so that callers can
+    shut down the service again during tests.
+    """
 
+    host = os.getenv("WS_HOST", "127.0.0.1")
+    port = port or int(os.getenv("METRICS_PORT", "48232"))
 
-
-
-
-
-
-    async def health_check(self, request):
-        from aiohttp import web
-        data = {'status': 'ok', **self.get_status()}
-        return web.json_response(data)
-
-
-
-
-
-
-
-
-
-async def start_metrics_api(voice_server, port=METRICS_PORT):
-    """Startet die HTTP Metrics API (bindet auf WS_HOST, Port aus Param/ENV)."""
-    metrics_api = MetricsAPI(voice_server)
-    runner = web.AppRunner(metrics_api.app)
+    app = create_app()
+    runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, WS_HOST, port)
+    site = web.TCPSite(runner, host, port)
     await site.start()
-    logger.info(f"📊 Metrics API server running on {WS_HOST}:{port}")
+    logger.info("📊 Metrics API server running on %s:%s", host, port)
     return runner
 
-if __name__ == "__main__":
-    pass
+
+__all__ = ["create_app", "start_http_server"]
+


### PR DESCRIPTION
## Summary
- add Prometheus-based metrics collector and HTTP endpoints for /metrics and /health
- start metrics server from CLI and expose connection/message counters
- instrument legacy WebSocket server and provide smoke test for metrics endpoint

## Testing
- `ruff check ws_server/metrics/collector.py ws_server/metrics/http_api.py ws_server/cli.py ws_server/compat/legacy_ws_server.py tests/smoke/http_metrics.py -q`
- `python -m pytest tests/smoke/http_metrics.py tests/smoke/binary_frame_roundtrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a86501ad10832481c995705fcb02e0