### PR TITLE
sprint-9: staged TTS fail-safety and metrics

### DIFF
--- a/tests/unit/test_staged_tts_fallback.py
+++ b/tests/unit/test_staged_tts_fallback.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "backend" / "ws-server"))
 from staged_tts.staged_processor import StagedTTSProcessor, StagedTTSConfig
+from ws_server.metrics.collector import collector
 
 
 class OnlyPiperManager:
@@ -22,7 +23,49 @@ class OnlyPiperManager:
 
 
 def test_fallback_to_piper_only():
+    collector.tts_engine_unavailable_total.labels(engine="zonos")._value.set(0)
+    collector.tts_chunk_emitted_total.labels(engine="piper")._value.set(0)
     proc = StagedTTSProcessor(OnlyPiperManager(), StagedTTSConfig(max_chunks=3))
     chunks = asyncio.run(proc.process_staged_tts("Hallo Welt. Noch ein Satz."))
     assert len(chunks) == 1
     assert chunks[0].engine == "piper"
+    proc.create_chunk_message(chunks[0])
+    assert collector.tts_engine_unavailable_total.labels(engine="zonos")._value.get() == 1
+    assert collector.tts_chunk_emitted_total.labels(engine="piper")._value.get() == 1
+
+
+class TimeoutManager:
+    engines = {"piper": object(), "zonos": object()}
+
+    async def synthesize(self, text, engine=None):
+        class R:
+            success = True
+            audio_data = b"x"
+            engine_used = engine
+            error_message = None
+
+        if engine == "piper":
+            await asyncio.sleep(0)
+            return R()
+        if engine == "zonos":
+            await asyncio.sleep(0.2)
+            return R()
+
+
+def test_timeout_counts_metric():
+    collector.tts_sequence_timeout_total.labels(engine="zonos")._value.set(0)
+    collector.tts_chunk_emitted_total.labels(engine="piper")._value.set(0)
+    proc = StagedTTSProcessor(
+        TimeoutManager(),
+        StagedTTSConfig(chunk_timeout_seconds=0.05, max_chunks=2),
+    )
+    text = "Hallo Welt. Noch ein Satz. " * 5
+    chunks = asyncio.run(proc.process_staged_tts(text))
+    # Only piper chunk succeeded
+    assert any(c.engine == "piper" for c in chunks)
+    assert any(c.engine == "zonos" and not c.success for c in chunks)
+    for c in chunks:
+        if c.engine == "piper":
+            proc.create_chunk_message(c)
+    assert collector.tts_sequence_timeout_total.labels(engine="zonos")._value.get() == 1
+    assert collector.tts_chunk_emitted_total.labels(engine="piper")._value.get() == 1

--- a/ws_server/metrics/collector.py
+++ b/ws_server/metrics/collector.py
@@ -68,6 +68,24 @@ class MetricsCollector:
             "Number of TTS cache misses",
             registry=self.registry,
         )
+        self.tts_chunk_emitted_total = Counter(
+            "tts_chunk_emitted_total",
+            "Number of emitted TTS chunks",
+            ["engine"],
+            registry=self.registry,
+        )
+        self.tts_sequence_timeout_total = Counter(
+            "tts_sequence_timeout_total",
+            "Number of TTS chunk timeouts",
+            ["engine"],
+            registry=self.registry,
+        )
+        self.tts_engine_unavailable_total = Counter(
+            "tts_engine_unavailable_total",
+            "Number of times a TTS engine was unavailable",
+            ["engine"],
+            registry=self.registry,
+        )
 
         # Histograms for latency measurements
         self.stt_latency = Histogram(


### PR DESCRIPTION
## Summary
- add Prometheus counters for emitted TTS chunks, timeouts, and unavailable engines
- ensure Piper failures fall back to text replies and always emit sequence end
- exercise new metrics with unit tests covering engine fallback and timeout paths

## Testing
- `ruff check backend/ws-server/staged_tts/staged_processor.py ws_server/compat/legacy_ws_server.py ws_server/metrics/collector.py tests/unit/test_staged_tts_fallback.py -q`
- `python -m pytest tests/unit/test_voice_aliases.py tests/unit/test_staged_tts_fallback.py tests/integration/staged_tts_flow.py tests/smoke/http_metrics.py tests/smoke/binary_frame_roundtrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a86f61e924832498bb2099c27a0e3a