### PR TITLE
sprint-13: add prosody-focused LLM prompt

### DIFF
--- a/tests/unit/test_llm_prosody_prompt.py
+++ b/tests/unit/test_llm_prosody_prompt.py
@@ -1,0 +1,17 @@
+from ws_server.core.prompt import get_system_prompt
+from ws_server.tts.staged_tts.chunking import optimize_for_prosody
+
+def test_system_prompt_clean_and_short():
+    prompt = get_system_prompt()
+    assert len(prompt) <= 500
+    assert "\n" not in prompt
+    assert "*" not in prompt and "#" not in prompt
+
+
+def test_optimize_for_prosody_strips_markdown():
+    text = "- Punkt eins\n- **fett** und [link](http://example.com)"  # noqa: E501
+    result = optimize_for_prosody(text)
+    assert "*" not in result
+    assert "[" not in result and "]" not in result
+    assert "link" in result
+    assert "\n" not in result

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -61,6 +61,7 @@ _PROJECT_ROOT = _P(__file__).resolve().parents[2]
 from backend.tts import TTSManager, TTSEngineType, TTSConfig
 from ws_server.tts.staged_tts import StagedTTSProcessor
 from ws_server.tts.staged_tts.staged_processor import StagedTTSConfig
+from ws_server.core.prompt import get_system_prompt
 from audio.vad import VoiceActivityDetector, VADConfig
 
 from auth.token_utils import verify_token
@@ -1100,10 +1101,7 @@ class VoiceServer:
 
         msgs = self._hist(client_id)
         if not msgs or msgs[0].get("role") != "system":
-            msgs.insert(0, {
-                "role": "system",
-                "content": "You are a concise, helpful voice assistant. Answer in the user's language. When unsure, ask a brief clarifying question."
-            })
+            msgs.insert(0, {"role": "system", "content": get_system_prompt()})
         msgs.append({"role": "user", "content": user_text})
         self._hist_trim(client_id)
 

--- a/ws_server/core/prompt.py
+++ b/ws_server/core/prompt.py
@@ -1,0 +1,14 @@
+"""LLM system prompt helpers."""
+
+from ws_server.tts.staged_tts import limit_and_chunk
+
+LLM_SYSTEM_PROMPT = (
+    "You are a friendly voice assistant. Reply in short, natural sentences that "
+    "sound like speech. Avoid lists or Markdown formatting. If something is "
+    "unclear, ask a brief follow-up question."
+)
+
+def get_system_prompt(max_length: int = 500) -> str:
+    """Return the system prompt limited to ``max_length`` characters."""
+    prompt = " ".join(LLM_SYSTEM_PROMPT.split())
+    return limit_and_chunk(prompt, max_length)[0]

--- a/ws_server/tts/staged_tts/chunking.py
+++ b/ws_server/tts/staged_tts/chunking.py
@@ -102,7 +102,12 @@ def optimize_for_prosody(text: str) -> str:
     result = text
     for num, word in number_replacements.items():
         result = result.replace(num, word)
-    
+
+    # Entferne einfache Markdown-Listen und Formatierungen
+    result = re.sub(r'^[\-\*\+]\s+', '', result, flags=re.MULTILINE)
+    result = re.sub(r'\[(.*?)\]\((.*?)\)', r'\1', result)
+    result = result.replace('**', '').replace('__', '').replace('`', '')
+
     # Entferne redundante Leerzeichen
     result = re.sub(r'\s+', ' ', result)
     


### PR DESCRIPTION
## Summary
- add central LLM system prompt trimmed via `limit_and_chunk`
- remove Markdown and list formatting before TTS chunking
- update legacy server to use new prompt

## Testing
- `ruff check ws_server backend/tts`
- `python scripts/repo_hygiene.py --check`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a876bb2c0c8324a42efd1b7005a498