### PR TITLE
sprint-14: validate TTS model assets

### DIFF
--- a/backend/tts/model_validation.py
+++ b/backend/tts/model_validation.py
@@ -1,0 +1,79 @@
+"""Utilities for validating local TTS model assets."""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def _check_file(path: Path) -> bool:
+    """Prüfe Datei und warne bei fehlenden oder defekten Symlinks."""
+    if path.is_symlink() and not path.exists():
+        logger.warning("Defekter Symlink: %s -> %s", path, os.readlink(path))
+        logger.info("💡 Beheben mit: ln -sf <Ziel> %s", path)
+        return False
+    if not path.is_file():
+        logger.warning("Fehlende Datei: %s", path)
+        return False
+    return True
+
+
+def _resolve_models_base(base_dir: str | None = None) -> Path:
+    """Return base directory for TTS models."""
+    if base_dir:
+        return Path(base_dir)
+    env = os.getenv("TTS_MODEL_DIR") or os.getenv("MODELS_DIR")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parents[2] / "models"
+
+
+def validate_models(base_dir: str | None = None) -> List[str]:
+    """Validate model files and return list of available voices."""
+    base = _resolve_models_base(base_dir)
+    piper_dir = base / "piper"
+    voices: List[str] = []
+    if not piper_dir.exists():
+        logger.warning("Modellverzeichnis fehlt: %s", piper_dir)
+        return voices
+
+    for onnx_file in sorted(piper_dir.glob("*.onnx")):
+        json_file = Path(str(onnx_file) + ".json")
+        _check_file(onnx_file)
+        _check_file(json_file)
+        voices.append(onnx_file.stem)
+
+    for json_file in piper_dir.glob("*.onnx.json"):
+        onnx_file = Path(str(json_file)[:-5])  # remove trailing '.json'
+        _check_file(json_file)
+        if not onnx_file.exists():
+            logger.warning("Konfigurationsdatei ohne Modell: %s", json_file)
+
+    return voices
+
+
+def list_voices_with_aliases(base_dir: str | None = None) -> Dict[str, List[str]]:
+    """Return mapping of canonical voices to their aliases."""
+    voices = validate_models(base_dir)
+    alias_map: Dict[str, List[str]] = {v: [] for v in voices}
+
+    try:
+        import importlib.util
+
+        va_path = Path(__file__).with_name("voice_aliases.py")
+        spec = importlib.util.spec_from_file_location("voice_aliases", va_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)  # type: ignore[assignment]
+        voice_aliases = getattr(module, "VOICE_ALIASES", {})
+    except Exception:  # pragma: no cover - fallback if file missing
+        voice_aliases = {}
+
+    for alias, canonical in voice_aliases.items():
+        if canonical in alias_map and alias != canonical:
+            alias_map[canonical].append(alias)
+    return alias_map
+

--- a/tests/unit/test_model_validation.py
+++ b/tests/unit/test_model_validation.py
@@ -1,0 +1,40 @@
+import importlib.util
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "model_validation", Path(__file__).resolve().parents[2] / "backend" / "tts" / "model_validation.py"
+)
+model_validation = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(model_validation)  # type: ignore[assignment]
+validate_models = model_validation.validate_models
+list_voices_with_aliases = model_validation.list_voices_with_aliases
+
+
+def test_missing_json_triggers_warning(tmp_path, caplog):
+    piper_dir = tmp_path / "piper"
+    piper_dir.mkdir()
+    (piper_dir / "voice.onnx").write_bytes(b"0")
+    validate_models(str(tmp_path))
+    assert "Fehlende Datei" in caplog.text
+
+
+def test_broken_symlink_warns(tmp_path, caplog):
+    piper_dir = tmp_path / "piper"
+    piper_dir.mkdir()
+    target = piper_dir / "missing.onnx"
+    (piper_dir / "voice.onnx").symlink_to(target)
+    (piper_dir / "voice.onnx.json").write_text("{}")
+    validate_models(str(tmp_path))
+    assert "Defekter Symlink" in caplog.text
+
+
+def test_list_voices_with_aliases(tmp_path):
+    piper_dir = tmp_path / "piper"
+    piper_dir.mkdir()
+    (piper_dir / "de_DE-thorsten-low.onnx").write_bytes(b"0")
+    (piper_dir / "de_DE-thorsten-low.onnx.json").write_text("{}")
+    aliases = list_voices_with_aliases(str(tmp_path))
+    assert "de_DE-thorsten-low" in aliases
+    assert "de-thorsten-low" in aliases["de_DE-thorsten-low"]

--- a/ws_server/cli.py
+++ b/ws_server/cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import asyncio
 import logging
 import os
@@ -6,10 +7,31 @@ import os
 from ws_server.transport.server import VoiceServer
 from ws_server.metrics.collector import collector
 from ws_server.metrics.http_api import start_http_server
+from backend.tts.model_validation import list_voices_with_aliases, validate_models
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
-async def main():
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--validate-models",
+        action="store_true",
+        help="TTS-Modelle prüfen und verfügbare Stimmen anzeigen",
+    )
+    args = parser.parse_args()
+
+    voices = validate_models()
+    if args.validate_models:
+        alias_map = list_voices_with_aliases()
+        for voice in voices:
+            aliases = alias_map.get(voice, [])
+            if aliases:
+                print(f"{voice}: {', '.join(aliases)}")
+            else:
+                print(voice)
+        return
+
     server = VoiceServer()
     await server.initialize()
 
@@ -28,6 +50,7 @@ async def main():
         logging.info("Unified WS-Server listening on ws://%s:%s", host, port)
         logging.info("📊 Metrics at :%s", metrics_port)
         await asyncio.Future()
+
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- add model validation utilities for Piper voices
- expose `--validate-models` flag to list voices and aliases
- cover missing configs and broken symlinks with tests

## Testing
- `ruff check ws_server backend/tts tests/unit/test_model_validation.py`
- `PYTHONPATH=. pytest -q`
- `scripts/repo_hygiene.py --check && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a878e9d0d48324b0f2a89a90755e0e