### PR TITLE
sprint-15: consolidate configuration defaults

### DIFF
--- a/config/tts.json
+++ b/config/tts.json
@@ -1,26 +1,3 @@
 {
-  "default_engine": "zonos",
-  "engines": {
-    "zonos": {
-      "type": "zonos",
-      "model": "Zyphra/Zonos-v0.1-transformer",
-      "language": "de",
-      "params": {
-        "emotion": "neutral",
-        "speed": 1.0
-      }
-    },
-    "piper": {
-      "type": "piper",
-      "voice": "de-thorsten-low",
-      "model_path": "/home/saschi/Sprachassistent/models/piper/de_DE-thorsten-low.onnx",
-      "config_path": "/home/saschi/Sprachassistent/models/piper/de_DE-thorsten-low.onnx.json"
-    },
-    "kokoro": {
-      "type": "kokoro",
-      "model_path": "/home/saschi/Sprachassistent/models/kokoro/kokoro-v1.0.onnx",
-      "voices_path": "/home/saschi/Sprachassistent/models/kokoro/voices-v1.0.bin",
-      "voice": "en_US-Bella"
-    }
-  }
+  "engines": {}
 }

--- a/testsuite/base_test.py
+++ b/testsuite/base_test.py
@@ -4,23 +4,21 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-from dotenv import load_dotenv
+from ws_server.core.config import load_env as _load_env
+
 
 class BaseTest:
     """Base test class providing environment loading utilities."""
 
     @staticmethod
     def load_env(profile: Optional[str] = None) -> None:
-        """Load environment variables from .env files.
+        """Load environment variables from ``.env`` files.
 
         Parameters
         ----------
-        profile: optional str
-            Name of the profile to load, e.g. ``all-in-one-pi``.
+        profile:
+            Optional profile name, e.g. ``all-in-one-pi``.
         """
-        env_file = Path(".env.defaults")
-        if profile:
-            candidate = Path(f".env.{profile}")
-            if candidate.exists():
-                env_file = candidate
-        load_dotenv(env_file, override=True)
+
+        env_file = Path(f".env.{profile}") if profile else Path(".env")
+        _load_env(env_file if env_file.exists() else None)

--- a/voice-assistant-apps/desktop/src/main.js
+++ b/voice-assistant-apps/desktop/src/main.js
@@ -86,8 +86,6 @@ function loadEnv() {
   const rootEnv = path.join(projectRoot, '.env');
   const localEnv = path.join(__dirname, '../.env');
   const envPath = fs.existsSync(rootEnv) ? rootEnv : localEnv;
-  const defaultsPath = path.join(path.dirname(envPath), '.env.defaults');
-  if (fs.existsSync(defaultsPath)) dotenv.config({ path: defaultsPath });
   dotenv.config({ path: envPath });
   log.info(`Loaded env from ${envPath}`);
 }

--- a/ws_server/cli.py
+++ b/ws_server/cli.py
@@ -8,6 +8,7 @@ from ws_server.transport.server import VoiceServer
 from ws_server.metrics.collector import collector
 from ws_server.metrics.http_api import start_http_server
 from backend.tts.model_validation import list_voices_with_aliases, validate_models
+from ws_server.core.config import load_env
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
@@ -32,12 +33,14 @@ async def main() -> None:
                 print(voice)
         return
 
+    load_env()
+
     server = VoiceServer()
     await server.initialize()
 
-    host = os.getenv("WS_HOST", "127.0.0.1")
-    port = int(os.getenv("WS_PORT", "48231"))
-    metrics_port = int(os.getenv("METRICS_PORT", "48232"))
+    host = os.getenv("WS_HOST")
+    port = int(os.getenv("WS_PORT"))
+    metrics_port = int(os.getenv("METRICS_PORT"))
 
     collector.start()
     await start_http_server(metrics_port)

--- a/ws_server/core/config.py
+++ b/ws_server/core/config.py
@@ -3,16 +3,64 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
+
+# Central default values. They mirror the previous contents of ``.env.defaults``
+# so that configuration is maintained in a single place.
+DEFAULT_ENV: dict[str, str] = {
+    "WS_HOST": "127.0.0.1",
+    "WS_PORT": "48231",
+    "METRICS_PORT": "48232",
+    "STT_ENGINE": "faster-whisper",
+    "TTS_ENGINE": "zonos",
+    "TTS_SPEED": "1.0",
+    "TTS_VOLUME": "1.0",
+    "TTS_MODEL_DIR": "./models",
+    "ZONOS_MODEL": "Zyphra/Zonos-v0.1-transformer",
+    "ZONOS_LANG": "de-de",
+    "ZONOS_VOICE": "thorsten",
+    "ZONOS_SPEAKER_DIR": "spk_cache",
+    "TTS_OUTPUT_SR": "48000",
+    "LLM_ENABLED": "true",
+    "LLM_API_BASE": "http://127.0.0.1:1234/v1",
+    "LLM_DEFAULT_MODEL": "auto",
+    "LLM_TEMPERATURE": "0.7",
+    "LLM_MAX_TOKENS": "256",
+    "LLM_MAX_TURNS": "5",
+    "LLM_TIMEOUT_SECONDS": "20",
+}
+
+
+def load_env(path: Optional[str | Path] = None) -> None:
+    """Load environment variables and apply defaults.
+
+    Parameters
+    ----------
+    path:
+        Optional path to a ``.env`` file. If ``None`` the repository root
+        ``.env`` is used when present.
+    """
+
+    env_path = Path(path) if path else Path(".env")
+    if env_path.exists():
+        load_dotenv(env_path, override=False)
+
+    for key, value in DEFAULT_ENV.items():
+        os.environ.setdefault(key, value)
 
 
 def get_tts_engine_default() -> str:
     """Return desired default TTS engine with fallback if Zonos is missing."""
+
     engine = os.getenv("TTS_ENGINE", "zonos").lower()
     if engine == "zonos":
         try:  # optional dependency
-            from backend.tts.engine_zonos import ZonosTTSEngine  # type: ignore # noqa:F401
+            from backend.tts.engine_zonos import ZonosTTSEngine  # type: ignore # noqa: F401
         except Exception as exc:  # pragma: no cover - import probe
             logger.warning("Zonos nicht verfügbar (%s) – falle auf Piper zurück", exc)
             engine = "piper"


### PR DESCRIPTION
## Summary
- centralize default settings in `core/config.py` and load them in the server CLI
- drop `.env.defaults` handling from the desktop launcher
- trim `config/tts.json` to user overrides only

## Testing
- `ruff check ws_server backend/tts`
- `python scripts/repo_hygiene.py --check`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87b2096dc832486c0ee1e8f18ecca