### PR TITLE
chore: refresh agents guide and add maintenance todos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,12 +69,11 @@ Client applications (Electron Desktop, Android Cordova, Web GUI) connect to the 
 
 ## Objective
 
-Codex should:
+Codex should continuously maintain and refine the codebase:
 
-1. Review, improve, and extend all previous sprints.
-2. Implement the new sprints (7–16).
-3. Apply changes in **small, atomic commits per sprint**.
-4. Maintain tests, logs, documentation, and repository hygiene.
+1. Review, improve, and extend existing features.
+2. Apply changes in **small, atomic commits**.
+3. Maintain tests, logs, documentation, and repository hygiene.
 
 ---
 
@@ -93,115 +92,19 @@ Codex should:
 
 ---
 
-## Sprints to Implement
+## Maintenance Plan
 
-### Sprint 1 — Binary Ingress
+Focus areas identified during repository analysis:
 
-* Extend WebSocket transport: JSON handshake + binary frames (OpCode 2).
-* Message structure: `type`, `op`, `payload`, `sequence_id`.
-* Audio streaming format: PCM16 LE.
-
-### Sprint 2 — Staged-TTS Pipeline
-
-* Implement `_limit_and_chunk(text)` (≤500 chars, 80–180 per chunk).
-* Implement `_tts_staged()`: Piper intro + Zonos in parallel.
-* Add WebSocket events: `tts_chunk`, `tts_sequence_end`.
-* Add Zonos timeout (8–10 s per chunk).
-
-### Sprint 3 — Metrics Collector
-
-* Add Prometheus metrics:
-
-  * `tts_chunk_emitted_total`
-  * `tts_sequence_timeout_total`
-  * `tts_engine_unavailable_total`
-* Expose endpoint `/metrics`.
-
-### Sprint 4 — Cleanup: Backups & Duplicates
-
-* Move `.bak`, `_fix`, `_indentfix`, legacy servers → `archive/`.
-* Maintain `DEPRECATIONS.md` (mapping old → new).
-* Only `ws_server/` remains as the active codebase.
-
-### Sprint 5 — Integration Tests
-
-* Smoke tests: handshake, ping/pong, full TTS sequence.
-* Unit tests: `_limit_and_chunk()`, `_tts_staged()` with dummy engines.
-
-### Sprint 6 — CI Workflow
-
-* GitHub Actions:
-
-  * `pytest -q`
-  * `scripts/repo_hygiene.py --check`
-  * `ruff` lint (`ws_server/**`, `backend/tts/**`).
-
-### Sprint 7 — Desktop/Electron Integration
-
-* Ensure Electron app launches `python -m ws_server.cli`.
-* Pass `.env` variables through (`WS_HOST`, `WS_PORT`, `JWT`, etc.).
-* Add `/health` check; show error dialog if server not reachable.
-
-### Sprint 8 — TTS Model Discovery & Voice Aliases
-
-* Implement alias map (e.g., `'de-thorsten-low': 'de_DE-thorsten-low'`).
-* Log all discovered models.
-* Zonos: optional registration → mark as unavailable instead of crashing.
-* Auto-fallback: Piper if Zonos is missing.
-
-### Sprint 9 — Staged-TTS Fail-Safety
-
-* Always attempt Piper intro.
-* On Zonos error/timeout: return Piper only, plus `tts_sequence_end`.
-
-### Sprint 10 — Repo Hygiene & Structure
-
-* `scripts/repo_hygiene.py` detects duplicates and moves them to `archive/`.
-* Maintain single server source: `ws_server/`.
-* `DEPRECATIONS.md` lists all replaced files.
-
-### Sprint 11 — CI Check “No Duplicates”
-
-* CI fails if `.bak` files, duplicates, or old server mirrors are found.
-
-### Sprint 12 — Desktop Client Playback Sequencer
-
-* Implement queue for `tts_chunk`/`tts_sequence_end`.
-* Add pre-buffering + 80–120 ms crossfade.
-* UI toggles: quickstart Piper, chunked playback, crossfade duration.
-
-### Sprint 13 — LLM Prosody Prompt
-
-* System prompt: ≤500 chars, natural speech style, no lists/Markdown.
-* Enforced via `_limit_and_chunk()`.
-
-### Sprint 14 — Model Asset Validation
-
-* On startup: check `.onnx` + `.onnx.json` presence.
-* Warn + suggest fix if broken symlinks.
-* CLI flag `--validate-models` lists available voices & aliases.
-
-### Sprint 15 — Config Consolidation
-
-* Centralize defaults in `core/config.py`.
-* Electron launcher loads `.env`, no separate JS defaults.
-* `config/tts.json` only contains user overrides.
-
-### Sprint 16 — Documentation & Release Notes
-
-* Add `docs/UNIFIED_SERVER.md`: entrypoint, events, settings.
-* Add `docs/STAGED_TTS.md`: timeouts, fallbacks, UX notes.
-* Release notes:
-
-  * **Breaking:** unified entrypoint
-  * **Deprecated:** legacy server files
-  * **New:** voice aliasing & model validation
-
----
+1. **Expand Test Coverage:** add dedicated unit tests for text chunking and intro creation.
+2. **Metrics Enhancements:** track memory usage and network throughput in the metrics collector.
+3. **Binary Audio Validation:** verify PCM format and sample rate in `binary_v2` before processing.
+4. **Configurable Prompts:** allow loading the LLM system prompt from configuration for localization.
+5. **TTS Crossfade:** make crossfade duration configurable for better UX experiments.
 
 ## Guidelines for Codex
 
-* **Commits:** one per sprint, message format `sprint-N: …`.
+* **Commits:** use clear, descriptive messages.
 * **Idempotency:** patches must be safe to apply multiple times.
 * **Logs:** in German, concise and clear.
 * **Tests:** write failing test first, then fix.

--- a/tests/unit/test_llm_prosody_prompt.py
+++ b/tests/unit/test_llm_prosody_prompt.py
@@ -1,6 +1,8 @@
 from ws_server.core.prompt import get_system_prompt
 from ws_server.tts.staged_tts.chunking import optimize_for_prosody
 
+# TODO: add unit tests for limit_and_chunk and create_intro_chunk utilities
+
 def test_system_prompt_clean_and_short():
     prompt = get_system_prompt()
     assert len(prompt) <= 500

--- a/ws_server/core/prompt.py
+++ b/ws_server/core/prompt.py
@@ -7,6 +7,7 @@ LLM_SYSTEM_PROMPT = (
     "sound like speech. Avoid lists or Markdown formatting. If something is "
     "unclear, ask a brief follow-up question."
 )
+# TODO: load default prompt from configuration to allow easy localization
 
 def get_system_prompt(max_length: int = 500) -> str:
     """Return the system prompt limited to ``max_length`` characters."""

--- a/ws_server/metrics/collector.py
+++ b/ws_server/metrics/collector.py
@@ -44,6 +44,7 @@ class MetricsCollector:
             "System wide CPU utilisation in percent",
             registry=self.registry,
         )
+        # TODO: add gauge for memory utilisation to detect leaks
 
         # Counters
         self.messages_total = Counter(

--- a/ws_server/protocol/binary_v2.py
+++ b/ws_server/protocol/binary_v2.py
@@ -106,7 +106,8 @@ class BinaryAudioHandler:
             if not frame:
                 await self._send_error(websocket, "Invalid binary frame format")
                 return
-            
+            # TODO: verify PCM parameters like sample rate and channels before forwarding
+
             # Update metrics
             self.metrics['frames_processed'] += 1
             self.metrics['bytes_received'] += frame.frame_size

--- a/ws_server/tts/staged_tts/staged_processor.py
+++ b/ws_server/tts/staged_tts/staged_processor.py
@@ -44,17 +44,18 @@ class StagedTTSConfig:
 class StagedTTSProcessor:
     """
     Hauptklasse für Staged TTS Processing
-    
+
     Implementiert das zweistufige System:
     - Stage A: Piper Intro (CPU, schnell)
     - Stage B: Zonos Hauptinhalt (GPU, hochwertig)
     """
-    
+
     def __init__(self, tts_manager, config: StagedTTSConfig = None):
         self.tts_manager = tts_manager
         self.config = config or StagedTTSConfig()
         # LRU Cache for synthesized audio
         self._cache: "OrderedDict[str, bytes]" = OrderedDict()
+        # TODO: allow configuring crossfade duration between Piper and Zonos stages
         
     async def process_staged_tts(self, text: str) -> List[TTSChunk]:
         """


### PR DESCRIPTION
## Summary
- drop obsolete sprint plan and document current maintenance tasks
- annotate core modules with TODOs for metrics, prompts, and audio validation
- note missing unit tests for chunking utilities

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87f54e3408324b50c76b1fff6c879