### PR TITLE
sprint-2(entrypoint): unify to ws_server.cli and harden import paths for legacy-free runtime

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -8,7 +8,7 @@
 | `backend/ws-server/ws-server-enhanced.py` | `ws_server/cli.py` |
 | `backend/ws-server/integration/migrate_to_binary.py` | _archived (obsolete)_ |
 | `backend/ws-server/migration_complete.py` | _archived (obsolete)_ |
-| `backend/ws-server/ws-server.py` | `ws_server/compat/legacy_ws_server.py` |
+| `backend/ws-server/ws-server.py` | `ws_server/cli.py` |
 | `backend/ws-server/ws-server-minimal.py` | `ws_server/compat/legacy_ws_server.py` |
 | `backend/ws-server/staged_tts/` | `ws_server/tts/staged_tts/` |
 | `backend/ws-server/` | `archive/legacy_ws_server/` |

--- a/debug_server_start.py
+++ b/debug_server_start.py
@@ -152,11 +152,8 @@ def debug_server_init():
     print("\n=== DEBUG: Server-Initialisierung ===")
     
     try:
-        # Change to backend/ws-server directory for proper imports
-        os.chdir('/home/saschi/Sprachassistent/backend/ws-server')
-        
-        # Try importing the server class
-        from ws_server import VoiceServer
+        # Try importing the server class from unified entrypoint
+        from ws_server.transport.server import VoiceServer
         print("✓ VoiceServer import erfolgreich")
 
         # Try creating instance

--- a/docs/Build-Anleitung.md
+++ b/docs/Build-Anleitung.md
@@ -12,7 +12,7 @@ Diese Anleitung zeigt, wie die **Standalone Desktop-App** (Electron GUI + Python
   - **Windows:** NSIS Installer; Backend-Binary idealerweise **nativ** auf Windows mit PyInstaller bauen.
 
 ## Übersicht
-- DEV-Modus: Electron startet `backend/ws-server/ws-server.py` direkt (Python).
+- DEV-Modus: Electron startet `python -m ws_server.cli` direkt.
 - PROD-Modus (paketiert): Electron startet das **Backend-Binary** aus `process.resourcesPath/bin/<platform>/`.
 
 ## Backend bauen (manuell, später ausführen)
@@ -22,7 +22,7 @@ Diese Anleitung zeigt, wie die **Standalone Desktop-App** (Electron GUI + Python
 ```bash
 . .venv/bin/activate   # falls vorhanden
 pip install --upgrade pip pyinstaller
-pyinstaller backend/ws-server/ws-server.py \
+pyinstaller ws_server/cli.py \
   --name ws-server --onefile --clean --noconfirm
 mkdir -p voice-assistant-apps/desktop/resources/bin/linux
 cp dist/ws-server voice-assistant-apps/desktop/resources/bin/linux/
@@ -33,7 +33,7 @@ chmod +x voice-assistant-apps/desktop/resources/bin/linux/ws-server
 
 ```powershell
 py -m pip install --upgrade pip pyinstaller
-pyinstaller backend/ws-server/ws-server.py --name ws-server --onefile --clean --noconfirm
+pyinstaller ws_server/cli.py --name ws-server --onefile --clean --noconfirm
 mkdir voice-assistant-apps\desktop\resources\bin\win -Force
 copy dist\ws-server.exe voice-assistant-apps\desktop\resources\bin\win\
 ```

--- a/docs/Projekt-Verbesserungen.md
+++ b/docs/Projekt-Verbesserungen.md
@@ -65,7 +65,7 @@ Sprachassistent/
 
 ### A. Async Audio Streaming mit FastAPI
 ```python
-# backend/ws-server/audio/streaming.py
+# archive/legacy_ws_server/audio/streaming.py
 import asyncio
 import aiofiles
 from fastapi import WebSocket
@@ -122,7 +122,7 @@ class AudioStreamer:
 
 ### B. Non-blocking STT/TTS Engine
 ```python
-# backend/ws-server/audio/stt_engine.py
+# archive/legacy_ws_server/audio/stt_engine.py
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from faster_whisper import WhisperModel
@@ -153,7 +153,7 @@ class AsyncSTTEngine:
 
 ### C. Optimierte WebSocket-Architektur
 ```python
-# backend/ws-server/main.py
+# archive/legacy_ws_server/main.py
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 import asyncio

--- a/docs/TTS-Engine-Switching.md
+++ b/docs/TTS-Engine-Switching.md
@@ -182,7 +182,7 @@ kokoro_config = TTSConfig(
 
 ### Server-Konfiguration
 
-In `backend/ws-server/ws-server-with-tts-switching.py`:
+In `archive/legacy_ws_server/ws-server-with-tts-switching.py`:
 
 ```python
 config = StreamingConfig(
@@ -273,7 +273,7 @@ pip install faster-whisper
 
 ```bash
 # Backend-Logs
-tail -f backend/ws-server/logs/ws-server.log
+tail -f archive/legacy_ws_server/logs/ws-server.log
 
 # TTS-spezifische Logs
 tail -f ~/.local/share/kokoro/logs/

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,5 +10,5 @@ Der WebSocket-Server schützt Zugriffe über zwei Mechanismen:
    verbinden. Verstöße werden mit dem WebSocket-Close-Code `4401` und dem Grund
    `unauthorized` abgewiesen.
 
-Die Tokenprüfung ist in `backend/ws-server/auth/token_utils.py` ausgelagert und
+Die Tokenprüfung ist in `archive/legacy_ws_server/auth/token_utils.py` ausgelagert und
 kann zukünftig durch eigene Module erweitert werden.

--- a/docs/skill-system.md
+++ b/docs/skill-system.md
@@ -1,7 +1,7 @@
 # Skill-System
 
 Der WebSocket-Server lädt zur Laufzeit Skills aus dem Ordner
-`backend/ws-server/skills`. Jeder Skill implementiert die Klasse
+`skills`. Jeder Skill implementiert die Klasse
 `BaseSkill` und kann so modular erweitert werden. Eine ML-gestützte
 Intent-Klassifikation entscheidet standardmäßig, welcher Skill aktiv ist.
 Fällt das Modell aus, greift eine Schlüsselwort-Heuristik als Fallback.

--- a/final_server_test.py
+++ b/final_server_test.py
@@ -26,7 +26,8 @@ def run_test():
     
     cmd = [
         "/home/saschi/Sprachassistent/.venv/bin/python",
-        "/home/saschi/Sprachassistent/backend/ws-server/ws-server.py"
+        "-m",
+        "ws_server.cli",
     ]
     
     env = os.environ.copy()
@@ -184,7 +185,7 @@ if __name__ == "__main__":
             print("\nTo start manually:")
             print("cd /home/saschi/Sprachassistent")
             print("source .venv/bin/activate")
-            print("python backend/ws-server/ws-server.py")
+            print("python -m ws_server.cli")
         else:
             print("\n🔧 VOICE ASSISTANT SERVER NEEDS MORE WORK")
             print("Check the detailed output above for specific issues.")

--- a/start_voice_assistant.py
+++ b/start_voice_assistant.py
@@ -117,7 +117,8 @@ def start_voice_assistant():
     # 3. Start server
     cmd = [
         "/home/saschi/Sprachassistent/.venv/bin/python",
-        "/home/saschi/Sprachassistent/backend/ws-server/ws-server.py"
+        "-m",
+        "ws_server.cli",
     ]
     
     env = os.environ.copy()

--- a/test_server_start.py
+++ b/test_server_start.py
@@ -22,8 +22,9 @@ def test_server_start():
     # Start server
     print("2️⃣  Starting server...")
     cmd = [
-        "/home/saschi/Sprachassistent/.venv/bin/python", 
-        "/home/saschi/Sprachassistent/backend/ws-server/ws-server.py"
+        "/home/saschi/Sprachassistent/.venv/bin/python",
+        "-m",
+        "ws_server.cli",
     ]
     
     print(f"Command: {' '.join(cmd)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/unit/test_desktop_entrypoint.py
+++ b/tests/unit/test_desktop_entrypoint.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_desktop_uses_unified_entrypoint():
+    main_js = Path("voice-assistant-apps/desktop/src/main.js").read_text(encoding="utf-8")
+    assert "['-m', 'ws_server.cli']" in main_js
+    assert "backend/ws-server/ws-server.py" not in main_js

--- a/tests/unit/test_transport_path_gate.py
+++ b/tests/unit/test_transport_path_gate.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+def _stub_compat():
+    stub = types.SimpleNamespace(VoiceServer=object)
+    sys.modules["ws_server.compat.legacy_ws_server"] = stub
+
+
+def test_blocks_legacy_module(monkeypatch):
+    _stub_compat()
+    sys.modules.pop("ws_server.transport.server", None)
+    fake = types.ModuleType("backend.ws_server.fake")
+    fake.__file__ = "/tmp/backend/ws-server/fake.py"
+    sys.modules["backend.ws_server.fake"] = fake
+    with pytest.raises(RuntimeError):
+        importlib.import_module("ws_server.transport.server")
+    sys.modules.pop("backend.ws_server.fake", None)
+    sys.modules.pop("ws_server.transport.server", None)
+    sys.modules.pop("ws_server.compat.legacy_ws_server", None)
+
+
+def test_import_ok_without_legacy(monkeypatch):
+    _stub_compat()
+    sys.modules.pop("ws_server.transport.server", None)
+    importlib.import_module("ws_server.transport.server")
+    sys.modules.pop("ws_server.transport.server", None)
+    sys.modules.pop("ws_server.compat.legacy_ws_server", None)

--- a/testsuite/test_token_utils.py
+++ b/testsuite/test_token_utils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 spec = importlib.util.spec_from_file_location(
     'token_utils',
-    Path(__file__).resolve().parents[1] / 'backend/ws-server/auth/token_utils.py'
+    Path(__file__).resolve().parents[1] / 'archive/legacy_ws_server/auth/token_utils.py'
 )
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)

--- a/ws_server/transport/server.py
+++ b/ws_server/transport/server.py
@@ -4,19 +4,31 @@ Unified server entrypoint:
 - Wrappt Legacy VoiceServer
 - Hängt Binary-Audio-Unterstützung & Metrics über die neuen Module an
 """
-import importlib.util
-import sys as _sys
-from pathlib import Path
+import sys
 
-# Legacy laden (in-place, ohne Code-Duplikate)
-_legacy = Path(__file__).resolve().parents[1] / "compat" / "legacy_ws_server.py"
-spec = importlib.util.spec_from_file_location("ws_server_legacy", _legacy)
-ws_server_legacy = importlib.util.module_from_spec(spec)
-assert spec and spec.loader
-# >>> WICHTIG: vor exec registrieren, damit @dataclass sys.modules[...] findet
-_sys.modules[spec.name] = ws_server_legacy
-spec.loader.exec_module(ws_server_legacy)  # type: ignore
-# type: ignore
+
+def _block_legacy_path() -> None:
+    """Verhindert Importe aus dem alten ``backend/ws-server`` Pfad."""
+    token = "backend/ws-server"
+    for name, mod in list(sys.modules.items()):
+        file = getattr(mod, "__file__", "") or ""
+        if token in file.replace("\\", "/"):
+            raise RuntimeError(f"Legacy-Modul nicht erlaubt: {file}")
+
+    class _Finder:
+        def find_spec(self, fullname, path, target=None):  # type: ignore[override]
+            if fullname.startswith("backend.ws_server"):
+                raise ModuleNotFoundError("backend/ws-server ist veraltet")
+            return None
+
+    if not any(isinstance(f, _Finder) for f in sys.meta_path):
+        sys.meta_path.insert(0, _Finder())
+
+
+_block_legacy_path()
+
+from ws_server.compat import legacy_ws_server as ws_server_legacy  # noqa: E402
 
 # Export der Legacy-VoiceServer-Klasse für Kompatibilität
 VoiceServer = ws_server_legacy.VoiceServer
+


### PR DESCRIPTION
## Summary
- ensure desktop app spawns `python -m ws_server.cli`
- add strict gate blocking legacy `backend/ws-server` imports
- document unified entrypoint and update deprecations

## Testing
- `python3 -m ruff check ws_server/transport/server.py tests/unit/test_desktop_entrypoint.py tests/unit/test_transport_path_gate.py tests/conftest.py`
- `pytest -q`
- `python scripts/repo_hygiene.py --check && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a88ae0b73483248ce2e65d011cdbd6