### PR TITLE
sprint-3(modularity): extract server monolith into core/protocol/transport/metrics/routing/tts/auth

### DIFF
--- a/testsuite/test_token_utils.py
+++ b/testsuite/test_token_utils.py
@@ -1,14 +1,4 @@
-import os
-import importlib.util
-from pathlib import Path
-
-spec = importlib.util.spec_from_file_location(
-    'token_utils',
-    Path(__file__).resolve().parents[1] / 'archive/legacy_ws_server/auth/token_utils.py'
-)
-module = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(module)
-verify_token = module.verify_token
+from ws_server.auth.token import verify_token
 
 
 def test_verify_token_plain(monkeypatch):

--- a/ws_server/auth/__init__.py
+++ b/ws_server/auth/__init__.py
@@ -1,1 +1,5 @@
-# package
+"""Authentication helpers for the WebSocket server."""
+
+from .token import verify_token
+
+__all__ = ["verify_token"]

--- a/ws_server/auth/rate_limit.py
+++ b/ws_server/auth/rate_limit.py
@@ -1,0 +1,9 @@
+"""Placeholder for future rate limiting utilities."""
+
+
+def check_rate_limit(token: str) -> bool:  # pragma: no cover - stub
+    """Stub for rate limiting; always allows the request."""
+    return True
+
+
+__all__ = ["check_rate_limit"]

--- a/ws_server/auth/token.py
+++ b/ws_server/auth/token.py
@@ -1,0 +1,39 @@
+import os
+from typing import Optional
+
+try:  # pragma: no cover - optional dependency
+    import jwt as pyjwt
+except Exception:  # pragma: no cover
+    pyjwt = None
+
+
+def verify_token(token: Optional[str]) -> bool:
+    """Verify a JWT or plain token according to environment settings."""
+    if os.getenv("JWT_BYPASS", "0") == "1":
+        return True
+
+    if not token:
+        if os.getenv("JWT_ALLOW_PLAIN", "0") == "1":
+            return True
+        return False
+
+    t = token.strip()
+    if t.lower().startswith("bearer "):
+        t = t[7:].strip()
+
+    secret = os.getenv("JWT_SECRET", "devsecret")
+
+    if os.getenv("JWT_ALLOW_PLAIN", "0") == "1" and t == secret:
+        return True
+
+    if pyjwt is not None:
+        try:
+            pyjwt.decode(t, secret, algorithms=["HS256"], options={"verify_aud": False})
+            return True
+        except Exception:
+            return False
+
+    return False
+
+
+__all__ = ["verify_token"]

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -58,13 +58,13 @@ _PROJECT_ROOT = _P(__file__).resolve().parents[2]
 (_sys.path.insert(0, str(_PROJECT_ROOT))
  if str(_PROJECT_ROOT) not in _sys.path else None)
 # ------------------------------------------
-from backend.tts import TTSManager, TTSEngineType, TTSConfig
+from ws_server.tts.manager import TTSManager, TTSEngineType, TTSConfig
 from ws_server.tts.staged_tts import StagedTTSProcessor
 from ws_server.tts.staged_tts.staged_processor import StagedTTSConfig
 from ws_server.core.prompt import get_system_prompt
 from audio.vad import VoiceActivityDetector, VADConfig
 
-from auth.token_utils import verify_token
+from ws_server.auth.token import verify_token
 from ws_server.metrics.collector import collector
 
 # Load environment variables from optional defaults then override with .env
@@ -78,30 +78,10 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Safe imports with fallbacks
-try:
-    from intent_classifier import IntentClassifier
-except ImportError as e:
-    logger.warning(f"Intent classifier not available: {e}")
-    class IntentClassifier:
-        def __init__(self, *args, **kwargs):
-            pass
-        def classify(self, text):
-            return type('obj', (object,), {'intent': 'unknown', 'confidence': 0.0})
-
-try:
-    from skills import load_all_skills
-except ImportError as e:
-    logger.warning(f"Skills module not available: {e}")
-    def load_all_skills(*args, **kwargs):
-        return []
-
-try:
-    from metrics_api import start_metrics_api
-except ImportError as e:
-    logger.error(f"Metrics API not available: {e}")
-    async def start_metrics_api(*args, **kwargs):
-        raise ImportError("Metrics API module not available")
+# Safe imports with fallbacks removed; modules now live in ws_server.routing
+from ws_server.routing.intent_router import IntentClassifier
+from ws_server.routing.skills import load_all_skills
+from ws_server.metrics.http_api import start_http_server as start_metrics_api
 
 # --- Helpers: Zonos-Language-Normalization & Kokoro-Voice listing ---
 def _normalize_zonos_lang():

--- a/ws_server/core/__init__.py
+++ b/ws_server/core/__init__.py
@@ -1,1 +1,7 @@
-# package
+"""Core utilities for the WebSocket server."""
+
+from .config import load_env
+from .connections import ConnectionStats
+from .streams import AudioStream
+
+__all__ = ["load_env", "ConnectionStats", "AudioStream"]

--- a/ws_server/core/config.py
+++ b/ws_server/core/config.py
@@ -6,7 +6,11 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from dotenv import load_dotenv
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover
+    def load_dotenv(*_args, **_kwargs):
+        return False
 
 logger = logging.getLogger(__name__)
 

--- a/ws_server/core/connections.py
+++ b/ws_server/core/connections.py
@@ -1,0 +1,12 @@
+"""Connection management utilities."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ConnectionStats:
+    active: int = 0
+    total: int = 0
+
+
+__all__ = ["ConnectionStats"]

--- a/ws_server/core/streams.py
+++ b/ws_server/core/streams.py
@@ -1,0 +1,12 @@
+"""Audio stream helpers."""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass
+class AudioStream:
+    samples: Iterable[int]
+
+
+__all__ = ["AudioStream"]

--- a/ws_server/protocol/handshake.py
+++ b/ws_server/protocol/handshake.py
@@ -1,0 +1,12 @@
+"""Protocol negotiation helpers."""
+
+from __future__ import annotations
+from typing import Any, Dict
+
+
+def build_ready(features: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Return a ready message for handshake replies."""
+    return {"op": "ready", "features": features or {}}
+
+
+__all__ = ["build_ready"]

--- a/ws_server/protocol/json_v1.py
+++ b/ws_server/protocol/json_v1.py
@@ -1,0 +1,13 @@
+"""JSON based message helpers (protocol v1)."""
+
+from __future__ import annotations
+from typing import Any, Dict
+
+
+def parse_message(data: str) -> Dict[str, Any]:
+    """Parse a JSON string into a dictionary."""
+    import json
+    return json.loads(data)
+
+
+__all__ = ["parse_message"]

--- a/ws_server/routing/__init__.py
+++ b/ws_server/routing/__init__.py
@@ -1,0 +1,12 @@
+"""Routing utilities for intents and skill management."""
+
+from .intent_router import IntentClassifier, IntentPrediction
+from .skills import load_all_skills, reload_skills, BaseSkill
+
+__all__ = [
+    "IntentClassifier",
+    "IntentPrediction",
+    "load_all_skills",
+    "reload_skills",
+    "BaseSkill",
+]

--- a/ws_server/routing/intent_router.py
+++ b/ws_server/routing/intent_router.py
@@ -1,0 +1,88 @@
+import logging
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import joblib  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    joblib = None
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IntentPrediction:
+    intent: str
+    confidence: float
+
+
+class IntentClassifier:
+    """Intent-Klassifizierer mit optionalem ML-Modell."""
+
+    def __init__(self, model_path: Optional[str] = "models/intent_classifier.bin"):
+        self.model = None
+        if joblib and model_path and Path(model_path).exists():
+            try:
+                self.model = joblib.load(model_path)
+                logger.info("Intent-Model geladen: %s", model_path)
+            except Exception as exc:
+                logger.error("Konnte Intent-Model nicht laden: %s", exc)
+        else:
+            # Train a lightweight model if no pre-trained model is available
+            try:
+                from sklearn.pipeline import Pipeline
+                from sklearn.feature_extraction.text import TfidfVectorizer
+                from sklearn.linear_model import LogisticRegression
+
+                train_texts = [
+                    "wie spät ist es",
+                    "hallo da",
+                    "danke dir",
+                    "frage zum wetter",
+                ]
+                train_labels = [
+                    "time_query",
+                    "greeting",
+                    "gratitude",
+                    "external_request",
+                ]
+                self.model = Pipeline([
+                    ("vec", TfidfVectorizer()),
+                    ("clf", LogisticRegression(max_iter=200)),
+                ])
+                self.model.fit(train_texts, train_labels)
+                logger.info("Intent-Model im Speicher trainiert")
+            except Exception as exc:
+                logger.warning(
+                    "Kein Intent-Model geladen, verwende Schlüsselwort-Fallback (%s)",
+                    exc,
+                )
+                self.model = None
+
+    def classify(self, text: str) -> IntentPrediction:
+        if self.model:
+            try:
+                probs = self.model.predict_proba([text])[0]
+                idx = probs.argmax()
+                intent = self.model.classes_[idx]
+                confidence = float(probs[idx])
+                logger.debug("Intent %s mit %.2f%%", intent, confidence * 100)
+                return IntentPrediction(intent, confidence)
+            except Exception as exc:
+                logger.error("Intent-Klassifikation fehlgeschlagen: %s", exc)
+
+        lower = text.lower()
+        if any(word in lower for word in ["zeit", "uhrzeit", "wie spät"]):
+            return IntentPrediction("time_query", 0.5)
+        if any(word in lower for word in ["hallo", "hi", "guten tag"]):
+            return IntentPrediction("greeting", 0.5)
+        if any(word in lower for word in ["danke", "vielen dank"]):
+            return IntentPrediction("gratitude", 0.5)
+        if any(
+            word in lower
+            for word in ["frage", "wissen", "hilfe", "wetter", "garage", "status"]
+        ):
+            return IntentPrediction("external_request", 0.5)
+        return IntentPrediction("unknown", 0.0)
+

--- a/ws_server/routing/skills.py
+++ b/ws_server/routing/skills.py
@@ -1,0 +1,40 @@
+from importlib import import_module, reload
+from pathlib import Path
+from typing import List, Optional
+import pkgutil
+
+class BaseSkill:
+    """Basis-Interface für alle Skills."""
+    intent_name: str = "base"
+
+    def can_handle(self, text: str) -> bool:
+        raise NotImplementedError
+
+    def handle(self, text: str) -> str:
+        raise NotImplementedError
+
+def _discover_modules(path: Path) -> List[str]:
+    return [name for _, name, _ in pkgutil.iter_modules([str(path)])]
+
+
+def load_all_skills(path: str | Path, enabled: Optional[List[str]] = None) -> List[BaseSkill]:
+    """Lade alle Skill-Klassen und unterstütze Hot-Reloading."""
+    skills: List[BaseSkill] = []
+    directory = Path(path)
+    for name in _discover_modules(directory):
+        if name.startswith("_"):
+            continue
+        module_name = f"{directory.name}.{name}"
+        module = import_module(module_name)
+        module = reload(module)
+        for obj in module.__dict__.values():
+            if isinstance(obj, type) and issubclass(obj, BaseSkill) and obj is not BaseSkill:
+                if enabled and obj.__name__ not in enabled:
+                    continue
+                skills.append(obj())
+    return skills
+
+
+def reload_skills(path: str | Path, enabled: Optional[List[str]] = None) -> List[BaseSkill]:
+    """Convenience wrapper to reload skills during runtime."""
+    return load_all_skills(path, enabled)

--- a/ws_server/transport/fastapi_adapter.py
+++ b/ws_server/transport/fastapi_adapter.py
@@ -1,0 +1,7 @@
+"""Placeholder for a future FastAPI transport adapter."""
+
+async def not_implemented(*_args, **_kwargs):  # pragma: no cover - stub
+    raise NotImplementedError("FastAPI adapter not yet implemented")
+
+
+__all__ = ["not_implemented"]

--- a/ws_server/tts/__init__.py
+++ b/ws_server/tts/__init__.py
@@ -1,1 +1,7 @@
-# package
+"""Text-to-Speech utilities and engine exports."""
+
+try:  # pragma: no cover - optional dependencies may be missing
+    from .manager import TTSManager, TTSConfig, TTSEngineType
+    __all__ = ["TTSManager", "TTSConfig", "TTSEngineType"]
+except Exception:  # pragma: no cover - expose empty API if manager unavailable
+    __all__: list[str] = []

--- a/ws_server/tts/engines/kokoro.py
+++ b/ws_server/tts/engines/kokoro.py
@@ -1,0 +1,9 @@
+"""Optional re-export of the Kokoro engine."""
+
+AVAILABLE = False
+try:  # pragma: no cover - import may fail
+    from backend.tts.kokoro_tts_engine import *  # type: ignore  # noqa: F401,F403
+    AVAILABLE = True
+except Exception as e:  # pragma: no cover
+    IMPORT_ERROR = e  # exposed for diagnostics
+    __all__ = []

--- a/ws_server/tts/engines/piper.py
+++ b/ws_server/tts/engines/piper.py
@@ -1,0 +1,9 @@
+"""Optional re-export of the Piper engine."""
+
+AVAILABLE = False
+try:  # pragma: no cover - import may fail
+    from backend.tts.piper_tts_engine import *  # type: ignore  # noqa: F401,F403
+    AVAILABLE = True
+except Exception as e:  # pragma: no cover
+    IMPORT_ERROR = e  # exposed for diagnostics
+    __all__ = []

--- a/ws_server/tts/manager.py
+++ b/ws_server/tts/manager.py
@@ -1,0 +1,5 @@
+"""Re-export of the TTS manager for uniform imports."""
+
+from backend.tts.tts_manager import TTSManager, TTSConfig, TTSEngineType
+
+__all__ = ["TTSManager", "TTSConfig", "TTSEngineType"]


### PR DESCRIPTION
## Summary
- add dedicated auth, routing, protocol, core and tts modules
- re-export backend TTS manager and token verification via new packages
- stub metrics collector to run without optional Prometheus dependency

## Testing
- `ruff check ws_server testsuite`
- `python scripts/repo_hygiene.py --check && echo "hygiene-ok"`
- `pytest -q`
- `python -m ws_server.cli --validate-models` *(fails: ModuleNotFoundError: No module named 'websockets')*


------
https://chatgpt.com/codex/tasks/task_e_68a88d30c94c83249bdb2e2de82dc8a6