### PR TITLE
Improve repo hygiene script

### DIFF
--- a/tests/unit/test_repo_hygiene.py
+++ b/tests/unit/test_repo_hygiene.py
@@ -1,0 +1,21 @@
+from scripts.repo_hygiene import find_issues
+
+
+def names(issues):
+    return {i.path.name: i.reason for i in issues}
+
+
+def test_detects_backup_and_pycache(tmp_path):
+    backup = tmp_path / "foo.py.bak"
+    backup.write_text("# test")
+    pycache = tmp_path / "__pycache__"
+    pycache.mkdir()
+    compiled = pycache / "mod.cpython-311.pyc"
+    compiled.write_bytes(b"0")
+
+    issues = find_issues(tmp_path)
+    mapping = names(issues)
+
+    assert backup.name in mapping and mapping[backup.name] == "Sicherungsdatei"
+    assert pycache.name in {i.path.name for i in issues}
+    assert compiled.name in mapping and mapping[compiled.name] == "Kompilierte Python-Datei"


### PR DESCRIPTION
## Summary
- enhance backup patterns and scan for `__pycache__` folders and `.pyc` files
- show detailed German messages per issue and summarize counts
- add unit test for hygiene scanner

## Testing
- `ruff check scripts/repo_hygiene.py tests/unit/test_repo_hygiene.py`
- `pytest -q`
- `python scripts/repo_hygiene.py --check`


------
https://chatgpt.com/codex/tasks/task_e_68a88ecb2794832497cfb6a4db0582b2