### PR TITLE
sprint-4(config): centralize settings, normalize env names, update docs

### DIFF
--- a/docs/UNIFIED_SERVER.md
+++ b/docs/UNIFIED_SERVER.md
@@ -17,6 +17,11 @@ include:
 | `WS_HOST` | Bind address for the WebSocket server |
 | `WS_PORT` | Port for client connections |
 | `METRICS_PORT` | HTTP port for the metrics endpoint |
+| `STT_MODEL` | Whisper/Faster-Whisper model name |
+| `STT_DEVICE` | Device for STT execution (`cpu`, `cuda`, ...) |
+| `TTS_ENGINE` | Default TTS engine (`zonos`, `piper`, ...) |
+| `TTS_VOICE` | Default voice identifier |
+| `JWT_SECRET` | Shared secret for token verification |
 
 ## Protocol
 

--- a/tests/unit/test_config_env.py
+++ b/tests/unit/test_config_env.py
@@ -1,0 +1,20 @@
+from ws_server.core.config import Config
+from ws_server.auth import token as token_module
+
+
+def test_config_from_env(monkeypatch):
+    monkeypatch.setenv("WS_HOST", "0.0.0.0")
+    monkeypatch.setenv("WS_PORT", "9999")
+    cfg = Config.from_env()
+    assert cfg.ws_host == "0.0.0.0"
+    assert cfg.ws_port == 9999
+
+
+def test_verify_token_respects_config(monkeypatch):
+    cfg = Config.from_env()
+    cfg.jwt_bypass = False
+    cfg.jwt_allow_plain = True
+    cfg.jwt_secret = "s3cr3t"
+    monkeypatch.setattr(token_module, "config", cfg)
+    assert token_module.verify_token("s3cr3t")
+    assert not token_module.verify_token("wrong")

--- a/ws_server/auth/token.py
+++ b/ws_server/auth/token.py
@@ -1,5 +1,6 @@
-import os
 from typing import Optional
+
+from ws_server.core.config import config
 
 try:  # pragma: no cover - optional dependency
     import jwt as pyjwt
@@ -8,27 +9,26 @@ except Exception:  # pragma: no cover
 
 
 def verify_token(token: Optional[str]) -> bool:
-    """Verify a JWT or plain token according to environment settings."""
-    if os.getenv("JWT_BYPASS", "0") == "1":
+    """Verify a JWT or plain token according to configuration settings."""
+
+    if config.jwt_bypass:
         return True
 
     if not token:
-        if os.getenv("JWT_ALLOW_PLAIN", "0") == "1":
-            return True
-        return False
+        return config.jwt_allow_plain
 
     t = token.strip()
     if t.lower().startswith("bearer "):
         t = t[7:].strip()
 
-    secret = os.getenv("JWT_SECRET", "devsecret")
-
-    if os.getenv("JWT_ALLOW_PLAIN", "0") == "1" and t == secret:
+    if config.jwt_allow_plain and t == config.jwt_secret:
         return True
 
     if pyjwt is not None:
         try:
-            pyjwt.decode(t, secret, algorithms=["HS256"], options={"verify_aud": False})
+            pyjwt.decode(
+                t, config.jwt_secret, algorithms=["HS256"], options={"verify_aud": False}
+            )
             return True
         except Exception:
             return False

--- a/ws_server/cli.py
+++ b/ws_server/cli.py
@@ -2,13 +2,12 @@
 import argparse
 import asyncio
 import logging
-import os
 
 from ws_server.transport.server import VoiceServer
 from ws_server.metrics.collector import collector
 from ws_server.metrics.http_api import start_http_server
 from backend.tts.model_validation import list_voices_with_aliases, validate_models
-from ws_server.core.config import load_env
+from ws_server.core.config import config
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
@@ -33,14 +32,12 @@ async def main() -> None:
                 print(voice)
         return
 
-    load_env()
-
     server = VoiceServer()
     await server.initialize()
 
-    host = os.getenv("WS_HOST")
-    port = int(os.getenv("WS_PORT"))
-    metrics_port = int(os.getenv("METRICS_PORT"))
+    host = config.ws_host
+    port = config.ws_port
+    metrics_port = config.metrics_port
 
     collector.start()
     await start_http_server(metrics_port)

--- a/ws_server/core/prompt.py
+++ b/ws_server/core/prompt.py
@@ -1,22 +1,13 @@
 """LLM system prompt helpers."""
 
-import os
-
 from ws_server.tts.staged_tts import limit_and_chunk
-
-# Default prompt can be overridden via environment for localisation
-DEFAULT_PROMPT = (
-    "You are a friendly voice assistant. Reply in short, natural sentences that "
-    "sound like speech. Avoid lists or Markdown formatting. If something is "
-    "unclear, ask a brief follow-up question."
-)
+from ws_server.core.config import config
 
 
 def get_system_prompt(max_length: int = 500) -> str:
     """Return the system prompt limited to ``max_length`` characters."""
 
-    prompt = os.getenv("LLM_SYSTEM_PROMPT", DEFAULT_PROMPT)
-    prompt = " ".join(prompt.split())
+    prompt = " ".join(config.llm_system_prompt.split())
     return limit_and_chunk(prompt, max_length)[0]
 
 

--- a/ws_server/metrics/http_api.py
+++ b/ws_server/metrics/http_api.py
@@ -9,11 +9,11 @@ and ``/health`` reports basic service status.
 from __future__ import annotations
 
 import logging
-import os
 from aiohttp import web
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from .collector import collector
+from ws_server.core.config import config
 
 logger = logging.getLogger(__name__)
 
@@ -43,8 +43,8 @@ async def start_http_server(port: int | None = None) -> web.AppRunner:
     shut down the service again during tests.
     """
 
-    host = os.getenv("WS_HOST", "127.0.0.1")
-    port = port or int(os.getenv("METRICS_PORT", "48232"))
+    host = config.ws_host
+    port = port or config.metrics_port
 
     app = create_app()
     runner = web.AppRunner(app)


### PR DESCRIPTION
## Summary
- add dataclass-based Config that loads `.env` defaults and centralizes env variables
- wire server components to use Config instead of scattered `os.getenv`
- document normalized env vars in unified server guide and cover configuration/token logic with tests

## Testing
- `ruff check ws_server tests/unit/test_config_env.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a890765c5c832483ae531c4493087e