### PR TITLE
sprint-5(tts): unify engine sources, add lazy loading and robust fallback

### DIFF
--- a/tests/unit/test_tts_manager_fallback.py
+++ b/tests/unit/test_tts_manager_fallback.py
@@ -1,0 +1,74 @@
+import asyncio
+import sys
+import types
+
+import backend.tts.tts_manager as tts_manager
+from backend.tts.base_tts_engine import TTSInitializationError
+from backend.tts.tts_manager import TTSConfig, TTSManager, TTSEngineType
+
+
+class FakePiper:
+    def __init__(self, config):
+        self.config = config
+
+    async def initialize(self):
+        return True
+
+    async def synthesize(self, text, voice=None, **kwargs):
+        class R:
+            success = True
+            audio_data = b"x"
+            engine_used = "piper"
+            error_message = None
+            processing_time_ms = 0.0
+        return R()
+
+    async def cleanup(self):
+        pass
+
+    def get_available_voices(self):
+        return ["default"]
+
+    def get_engine_info(self):
+        return {"name": "fake"}
+
+
+class FakeZonos:
+    def __init__(self, config):
+        self.config = config
+
+    async def initialize(self):
+        raise TTSInitializationError("missing model")
+
+
+# Stub-Module in sys.modules eintragen
+fake_piper_mod = types.ModuleType("fake_piper")
+fake_piper_mod.FakePiper = FakePiper
+sys.modules["fake_piper"] = fake_piper_mod
+
+fake_zonos_mod = types.ModuleType("fake_zonos")
+fake_zonos_mod.FakeZonos = FakeZonos
+sys.modules["fake_zonos"] = fake_zonos_mod
+
+
+def test_fallback_to_piper_when_zonos_missing(monkeypatch):
+    monkeypatch.setattr(
+        tts_manager,
+        "ENGINE_IMPORTS",
+        {
+            "piper": ("fake_piper", "FakePiper"),
+            "zonos": ("fake_zonos", "FakeZonos"),
+        },
+        raising=False,
+    )
+    mgr = TTSManager()
+    p_cfg = TTSConfig(engine_type="piper")
+    z_cfg = TTSConfig(engine_type="zonos")
+    init_ok = asyncio.run(
+        mgr.initialize(piper_config=p_cfg, zonos_config=z_cfg, default_engine=TTSEngineType.ZONOS)
+    )
+    assert init_ok is True
+    assert mgr.default_engine == "piper"
+    assert "zonos" in mgr.unavailable_engines
+    res = asyncio.run(mgr.synthesize("hi"))
+    assert res.engine_used == "piper"


### PR DESCRIPTION
## Summary
- refactor TTSManager to lazy-load engine implementations and map imports centrally
- automatically fall back to Piper when Zonos initialization fails
- add unit test exercising Piper fallback when Zonos assets are missing

## Testing
- `ruff check backend/tts/tts_manager.py tests/unit/test_tts_manager_fallback.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89261fcf48324893db4227eb35e2b