### PR TITLE
sprint-7(protocol): handshake negotiation; add binary audio ingress alongside JSON v1

### DIFF
--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -9,7 +9,7 @@ focused commit.
 - [x] Sprint 4 — Config consolidation & naming hygiene
 - [x] Sprint 5 — TTS single source of truth & lazy loading
 - [x] Sprint 6 — STT in-memory & streaming-friendly
-- [ ] Sprint 7 — Binary ingress + JSON compatibility
+- [x] Sprint 7 — Binary ingress + JSON compatibility
 - [ ] Sprint 8 — Staged TTS UX (intro Piper, main Zonos)
 - [ ] Sprint 9 — Metrics unification
 - [ ] Sprint 10 — Intent routing & skills completion

--- a/docs/UNIFIED_SERVER.md
+++ b/docs/UNIFIED_SERVER.md
@@ -31,8 +31,11 @@ Streaming-Unterstützung folgt.
 
 ## Protocol
 
-Clients connect via WebSocket.  A `hello` message is exchanged during the
-handshake, followed by JSON messages or binary audio frames.
+Clients connect via WebSocket.  During the handshake the client sends either
+`{"op": "hello"}` or the legacy form `{"type": "hello"}`.  The server
+responds with `{"op": "ready", "features": {"binary_audio": true}}` to
+advertise binary audio frame support.  After this exchange clients may stream
+PCM16 audio either as base64 encoded JSON chunks or as native binary frames.
 
 ## Health & Metrics
 

--- a/tests/integration/test_binary_json_compat.py
+++ b/tests/integration/test_binary_json_compat.py
@@ -1,0 +1,69 @@
+import base64
+import json
+
+import pytest
+
+from ws_server.protocol.binary_v2 import BinaryAudioHandler, build_audio_frame
+
+
+class DummyWebSocket:
+    def __init__(self):
+        self.sent: list[str] = []
+
+    async def send(self, msg: str) -> None:  # pragma: no cover - trivial
+        self.sent.append(msg)
+
+
+class StubSTT:
+    def __init__(self):
+        self.binary_calls = []
+
+    async def process_binary_audio(self, data, stream_id, sequence):
+        self.binary_calls.append((stream_id, sequence, data))
+        return {"text": "bin"}
+
+
+class StubMessageHandler:
+    def __init__(self):
+        self.calls = []
+
+    async def handle_audio_message(self, websocket, data):
+        self.calls.append(data)
+        return {"text": "json"}
+
+
+@pytest.mark.asyncio
+async def test_binary_and_json_ingress():
+    audio = (1).to_bytes(2, "little")  # single PCM16 sample
+
+    # ---- Binary client --------------------------------------------------
+    ws = DummyWebSocket()
+    stt = StubSTT()
+    mh = StubMessageHandler()
+    handler = BinaryAudioHandler()
+    frame = build_audio_frame("stream", 0, 0.0, audio)
+    await handler.handle_binary_message(ws, frame, stt, mh)
+    assert stt.binary_calls
+    assert json.loads(ws.sent[0])["type"] == "stt_result"
+
+    # ---- JSON fallback client ------------------------------------------
+    ws_json = DummyWebSocket()
+    mh_json = StubMessageHandler()
+    b64 = base64.b64encode(audio).decode("ascii")
+    msg = {"stream_id": "j", "chunk": b64, "sequence": 0, "is_binary": False}
+    result = await mh_json.handle_audio_message(ws_json, msg)
+    assert mh_json.calls[0]["chunk"] == b64
+    assert result == {"text": "json"}
+
+    # ---- Binary STT fallback to JSON path ------------------------------
+    ws_fb = DummyWebSocket()
+    mh_fb = StubMessageHandler()
+
+    class NoBinarySTT:  # lacks process_binary_audio
+        pass
+
+    frame_fb = build_audio_frame("fb", 1, 0.0, audio)
+    await handler.handle_binary_message(ws_fb, frame_fb, NoBinarySTT(), mh_fb)
+    # message handler should have been invoked with base64 encoded data
+    assert mh_fb.calls
+    assert isinstance(mh_fb.calls[0]["audio_data"], str)

--- a/tests/unit/test_protocol_handshake.py
+++ b/tests/unit/test_protocol_handshake.py
@@ -1,0 +1,24 @@
+from ws_server.protocol.handshake import parse_client_hello, build_ready
+
+
+def test_parse_client_hello_modern_and_legacy():
+    modern = {"op": "hello", "features": {"x": 1}}
+    legacy = {"type": "hello"}
+
+    assert parse_client_hello(modern)["features"] == {"x": 1}
+    assert parse_client_hello(legacy)["op"] == "hello"
+
+
+def test_build_ready_features():
+    msg = build_ready({"binary_audio": True})
+    assert msg == {"op": "ready", "features": {"binary_audio": True}}
+
+
+def test_parse_client_hello_invalid():
+    try:
+        parse_client_hello({"op": "nope"})
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        assert "unexpected" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("parse_client_hello did not raise")
+

--- a/ws_server/protocol/handshake.py
+++ b/ws_server/protocol/handshake.py
@@ -4,9 +4,25 @@ from __future__ import annotations
 from typing import Any, Dict
 
 
+def parse_client_hello(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate and normalize client hello payload.
+
+    Supports both the modern ``{"op": "hello"}`` format and the legacy
+    ``{"type": "hello"}`` variant.
+
+    Returns a normalized mapping with an ``op`` field set to ``"hello"`` and
+    a ``features`` dictionary.
+    """
+
+    op = data.get("op") or data.get("type")
+    if op != "hello":  # pragma: no cover - defensive
+        raise ValueError("unexpected handshake op")
+    return {"op": "hello", "features": data.get("features", {})}
+
+
 def build_ready(features: Dict[str, Any] | None = None) -> Dict[str, Any]:
     """Return a ready message for handshake replies."""
     return {"op": "ready", "features": features or {}}
 
 
-__all__ = ["build_ready"]
+__all__ = ["parse_client_hello", "build_ready"]


### PR DESCRIPTION
## Summary
- Accept both `op` and legacy `type` client hellos and advertise features via `op:ready`
- Parse/build binary audio frames and route to STT while keeping JSON base64 fallback
- Update unified server docs and refactor plan checklist

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8980506a883249db3b0f98b86c4a4