### PR TITLE
test(chunking): cover 500-char limit

### DIFF
--- a/tests/unit/test_llm_prosody_prompt.py
+++ b/tests/unit/test_llm_prosody_prompt.py
@@ -28,6 +28,13 @@ def test_limit_and_chunk_bounds_and_length():
     assert all(80 <= len(c) <= 180 for c in chunks[:-1])
 
 
+def test_limit_and_chunk_respects_500_char_limit():
+    text = "Dies ist ein sehr langer Text. " * 40
+    chunks = _limit_and_chunk(text)
+    assert sum(len(c) for c in chunks) <= 500
+    assert all(80 <= len(c) <= 180 for c in chunks[:-1])
+
+
 def test_create_intro_chunk_splits_intro():
     chunks = [
         "Dies ist ein wirklich sehr langer Satz, der als Intro dienen soll und daher gekürzt werden muss, damit er nicht zu lang wird.",


### PR DESCRIPTION
## Summary
- add unit test to ensure `_limit_and_chunk` keeps output under the 500 character cap

## Testing
- `ruff check tests/unit/test_llm_prosody_prompt.py`
- `pytest tests/unit/test_llm_prosody_prompt.py -q`
- `python scripts/repo_hygiene.py --check`


------
https://chatgpt.com/codex/tasks/task_e_68a89b67052c83249b284ef47271f42b