### PR TITLE
sprint-9(metrics): unify collector + HTTP endpoints for health and Prometheus scraping

### DIFF
--- a/tests/unit/test_audio_throughput_metrics.py
+++ b/tests/unit/test_audio_throughput_metrics.py
@@ -1,0 +1,47 @@
+import asyncio
+import time
+
+from ws_server.metrics.collector import collector
+from ws_server.protocol.binary_v2 import BinaryAudioHandler, build_audio_frame
+from ws_server.tts.staged_tts.staged_processor import TTSChunk, StagedTTSProcessor
+
+
+class _StubWebSocket:
+    async def send(self, _data):
+        pass
+
+
+class _StubSTT:
+    sample_rate = 16000
+    channels = 1
+
+    async def process_binary_audio(self, _data, stream_id, sequence):
+        return None
+
+
+async def _handle_audio_frame():
+    handler = BinaryAudioHandler()
+    frame = build_audio_frame("stream", 1, time.time(), b"\x00\x00" * 10)
+    await handler.handle_binary_message(_StubWebSocket(), frame, _StubSTT(), object())
+
+
+def test_audio_in_bytes_metric():
+    collector.audio_in_bytes_total._value.set(0)
+    asyncio.run(_handle_audio_frame())
+    assert collector.audio_in_bytes_total._value.get() == 20
+
+
+def test_audio_out_bytes_metric():
+    collector.audio_out_bytes_total._value.set(0)
+    chunk = TTSChunk(
+        sequence_id="seq",
+        index=0,
+        total=1,
+        engine="piper",
+        text="hi",
+        audio_data=b"12345678",
+        success=True,
+    )
+    proc = StagedTTSProcessor(object())
+    proc.create_chunk_message(chunk)
+    assert collector.audio_out_bytes_total._value.get() == 8

--- a/ws_server/metrics/collector.py
+++ b/ws_server/metrics/collector.py
@@ -125,6 +125,18 @@ class MetricsCollector:
             registry=self.registry,
         )
 
+        # Audio throughput counters
+        self.audio_in_bytes_total = Counter(
+            "audio_in_bytes_total",
+            "Total number of audio bytes received from clients",
+            registry=self.registry,
+        )
+        self.audio_out_bytes_total = Counter(
+            "audio_out_bytes_total",
+            "Total number of audio bytes sent to clients",
+            registry=self.registry,
+        )
+
         # Histograms for latency measurements
         self.stt_latency = Histogram(
             "stt_latency_seconds",

--- a/ws_server/protocol/binary_v2.py
+++ b/ws_server/protocol/binary_v2.py
@@ -5,6 +5,8 @@ from typing import Dict, Any, Optional
 import time
 from dataclasses import dataclass
 
+from ws_server.metrics.collector import collector
+
 logger = logging.getLogger(__name__)
 
 
@@ -119,6 +121,7 @@ class BinaryAudioHandler:
             # Update metrics
             self.metrics['frames_processed'] += 1
             self.metrics['bytes_received'] += frame.frame_size
+            collector.audio_in_bytes_total.inc(len(frame.audio_data))
             
             # Track stream
             if frame.stream_id not in self.active_streams:

--- a/ws_server/tts/staged_tts/staged_processor.py
+++ b/ws_server/tts/staged_tts/staged_processor.py
@@ -235,6 +235,7 @@ class StagedTTSProcessor:
             audio_b64 = base64.b64encode(chunk.audio_data).decode("utf-8")
         if chunk.success and chunk.audio_data:
             collector.tts_chunk_emitted_total.labels(engine=chunk.engine).inc()
+            collector.audio_out_bytes_total.inc(len(chunk.audio_data))
 
         return {
             "type": "tts_chunk",


### PR DESCRIPTION
## Summary
- track audio throughput with unified metrics collector
- count incoming audio bytes in binary protocol and outgoing chunk bytes in TTS processor
- exercise new metrics via unit tests

## Testing
- `ruff check ws_server/metrics/collector.py ws_server/protocol/binary_v2.py ws_server/tts/staged_tts/staged_processor.py tests/unit/test_audio_throughput_metrics.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a89d02ca648324b98d7a01b48d3fb2