### PR TITLE
Sprint 10: intent router with plugin skills and optional Flowise/n8n integration

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -14,3 +14,4 @@
 | `backend/ws-server/` | `archive/legacy_ws_server/` |
 | `backend/ws-server/README.md` | `archive/legacy_ws_server/README.md` |
 | `ws_server/transport/fastapi_adapter.py` | _archived (unused)_ |
+| `archive/legacy_ws_server/skills/` | `ws_server/skills/` |

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -12,7 +12,7 @@ focused commit.
 - [x] Sprint 7 — Binary ingress + JSON compatibility
 - [x] Sprint 8 — Staged TTS UX (intro Piper, main Zonos)
 - [x] Sprint 9 — Metrics unification
-- [ ] Sprint 10 — Intent routing & skills completion
+- [x] Sprint 10 — Intent routing & skills completion
 - [ ] Sprint 11 — Error handling & client resilience
 - [ ] Sprint 12 — Model discovery & validation
 - [ ] Sprint 13 — Configurable LLM prosody prompt

--- a/tests/unit/test_intent_router.py
+++ b/tests/unit/test_intent_router.py
@@ -1,0 +1,35 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ws_server.routing.intent_router import IntentRouter
+
+
+@pytest.mark.asyncio
+async def test_routes_local_skill():
+    router = IntentRouter()
+    result = await router.route("hallo")
+    assert "Hallo" in result
+
+
+@pytest.mark.asyncio
+async def test_routes_flowise(monkeypatch):
+    monkeypatch.setenv("FLOWISE_URL", "http://flowise")
+    router = IntentRouter()
+    mock_call = AsyncMock(return_value="flowise-answer")
+    monkeypatch.setattr(router, "_call_flowise", mock_call)
+    out = await router.route("frage zum wetter")
+    mock_call.assert_awaited_once()
+    assert out == "flowise-answer"
+
+
+@pytest.mark.asyncio
+async def test_routes_n8n(monkeypatch):
+    monkeypatch.setenv("N8N_HOST", "localhost")
+    router = IntentRouter()
+    mock_call = AsyncMock(return_value="automation-done")
+    monkeypatch.setattr(router, "_call_n8n", mock_call)
+    out = await router.route("schalte das licht ein")
+    mock_call.assert_awaited_once()
+    assert out == "automation-done"

--- a/ws_server/routing/__init__.py
+++ b/ws_server/routing/__init__.py
@@ -1,11 +1,12 @@
 """Routing utilities for intents and skill management."""
 
-from .intent_router import IntentClassifier, IntentPrediction
+from .intent_router import IntentClassifier, IntentPrediction, IntentRouter
 from .skills import load_all_skills, reload_skills, BaseSkill
 
 __all__ = [
     "IntentClassifier",
     "IntentPrediction",
+    "IntentRouter",
     "load_all_skills",
     "reload_skills",
     "BaseSkill",

--- a/ws_server/routing/skills.py
+++ b/ws_server/routing/skills.py
@@ -1,6 +1,9 @@
+"""Utility helpers to discover and load skill plugins."""
+
 from importlib import import_module, reload
 from pathlib import Path
 from typing import List, Optional
+
 import pkgutil
 
 class BaseSkill:
@@ -17,24 +20,38 @@ def _discover_modules(path: Path) -> List[str]:
     return [name for _, name, _ in pkgutil.iter_modules([str(path)])]
 
 
-def load_all_skills(path: str | Path, enabled: Optional[List[str]] = None) -> List[BaseSkill]:
+def load_all_skills(
+    path: str | Path | None = None, enabled: Optional[List[str]] = None
+) -> List[BaseSkill]:
     """Lade alle Skill-Klassen und unterstütze Hot-Reloading."""
-    skills: List[BaseSkill] = []
+
+    if path is None:
+        path = Path(__file__).resolve().parent.parent / "skills"
     directory = Path(path)
+    package_base = ".".join(directory.parts[-2:])
+
+    skills: List[BaseSkill] = []
     for name in _discover_modules(directory):
         if name.startswith("_"):
             continue
-        module_name = f"{directory.name}.{name}"
+        module_name = f"{package_base}.{name}"
         module = import_module(module_name)
         module = reload(module)
         for obj in module.__dict__.values():
-            if isinstance(obj, type) and issubclass(obj, BaseSkill) and obj is not BaseSkill:
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, BaseSkill)
+                and obj is not BaseSkill
+            ):
                 if enabled and obj.__name__ not in enabled:
                     continue
                 skills.append(obj())
     return skills
 
 
-def reload_skills(path: str | Path, enabled: Optional[List[str]] = None) -> List[BaseSkill]:
+def reload_skills(
+    path: str | Path | None = None, enabled: Optional[List[str]] = None
+) -> List[BaseSkill]:
     """Convenience wrapper to reload skills during runtime."""
+
     return load_all_skills(path, enabled)

--- a/ws_server/skills/__init__.py
+++ b/ws_server/skills/__init__.py
@@ -1,0 +1,3 @@
+from ws_server.routing.skills import BaseSkill
+
+__all__ = ["BaseSkill"]

--- a/ws_server/skills/gratitude_skill.py
+++ b/ws_server/skills/gratitude_skill.py
@@ -1,0 +1,13 @@
+from . import BaseSkill
+
+
+class GratitudeSkill(BaseSkill):
+    """Reagiert auf Dank."""
+
+    intent_name = "gratitude"
+
+    def can_handle(self, text: str) -> bool:
+        return any(word in text.lower() for word in ["danke", "vielen dank"])
+
+    def handle(self, text: str) -> str:
+        return "Gern geschehen!"

--- a/ws_server/skills/greeting_skill.py
+++ b/ws_server/skills/greeting_skill.py
@@ -1,0 +1,13 @@
+from . import BaseSkill
+
+
+class GreetingSkill(BaseSkill):
+    """Begrüßt den Nutzer."""
+
+    intent_name = "greeting"
+
+    def can_handle(self, text: str) -> bool:
+        return any(word in text.lower() for word in ["hallo", "hi", "guten tag"])
+
+    def handle(self, text: str) -> str:
+        return "Hallo! Wie kann ich Ihnen helfen?"

--- a/ws_server/skills/time_skill.py
+++ b/ws_server/skills/time_skill.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from . import BaseSkill
+
+
+class TimeSkill(BaseSkill):
+    """Gibt die aktuelle Uhrzeit zurück."""
+
+    intent_name = "time_query"
+
+    def can_handle(self, text: str) -> bool:
+        return any(word in text.lower() for word in ["zeit", "uhrzeit", "wie spät"])
+
+    def handle(self, text: str) -> str:
+        return f"Es ist {datetime.now().strftime('%H:%M')} Uhr."


### PR DESCRIPTION
## Summary
- add IntentRouter with local skill dispatch and optional Flowise/n8n calls
- introduce plugin loader and sample greeting, gratitude, and time skills
- mark sprint 10 complete in refactor plan

## Testing
- `ruff check ws_server/routing/intent_router.py ws_server/routing/skills.py ws_server/skills tests/unit/test_intent_router.py`
- `pytest -q`
- `python scripts/repo_hygiene.py --check`


------
https://chatgpt.com/codex/tasks/task_e_68a89e3b5ed08324b5bfc655a48b0655