### PR TITLE
sprint-11(hardening): structured errors, graceful sequence closes, desktop reconnect with backoff

### DIFF
--- a/tests/unit/test_binary_error_structure.py
+++ b/tests/unit/test_binary_error_structure.py
@@ -1,0 +1,20 @@
+import asyncio
+import json
+from ws_server.protocol.binary_v2 import BinaryAudioHandler
+
+
+class DummyWebSocket:
+    def __init__(self):
+        self.data = None
+    async def send(self, payload):
+        self.data = payload
+
+
+def test_send_error_structured():
+    handler = BinaryAudioHandler()
+    ws = DummyWebSocket()
+    asyncio.run(handler._send_error(ws, 'test_code', 'oops'))
+    msg = json.loads(ws.data)
+    assert msg['type'] == 'error'
+    assert msg['code'] == 'test_code'
+    assert msg['message'] == 'oops'


### PR DESCRIPTION
## Summary
- send structured error responses from binary protocol
- ensure staged TTS fallback closes sequences and reports failures
- desktop client probes health, reconnects with backoff, and shows connection errors

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a12635608324804cfee809221267