### PR TITLE
sprint-13(llm-prosody): add speakable system prompt and hard-cap chunking

### DIFF
--- a/tests/unit/test_llm_prosody_prompt.py
+++ b/tests/unit/test_llm_prosody_prompt.py
@@ -1,3 +1,7 @@
+import sys
+import types
+import pytest
+
 from ws_server.core.prompt import get_system_prompt
 from ws_server.tts.staged_tts.chunking import (
     optimize_for_prosody,
@@ -5,11 +9,26 @@ from ws_server.tts.staged_tts.chunking import (
     create_intro_chunk,
 )
 
+
+def _get_voice_server():
+    sys.modules.setdefault(
+        "faster_whisper", types.SimpleNamespace(WhisperModel=object)
+    )
+    fake_vad = types.SimpleNamespace(VoiceActivityDetector=object, VADConfig=object)
+    sys.modules.setdefault("audio", types.SimpleNamespace(vad=fake_vad))
+    sys.modules.setdefault("audio.vad", fake_vad)
+    from ws_server.compat.legacy_ws_server import VoiceServer
+
+    return VoiceServer
+
+
 def test_system_prompt_clean_and_short():
     prompt = get_system_prompt()
     assert len(prompt) <= 500
     assert "\n" not in prompt
     assert "*" not in prompt and "#" not in prompt
+    assert "short" in prompt.lower()
+    assert "500" in prompt
 
 
 def test_optimize_for_prosody_strips_markdown():
@@ -44,3 +63,27 @@ def test_create_intro_chunk_splits_intro():
     assert len(intro) <= 60
     assert rest
     assert rest[0].startswith(chunks[0][len(intro):].strip())
+
+
+@pytest.mark.asyncio
+async def test_ask_llm_caps_long_response():
+    VoiceServer = _get_voice_server()
+    server = VoiceServer.__new__(VoiceServer)
+    server.llm_enabled = True
+    server.llm_model = "test"
+    server.llm_temperature = 0.7
+    server.llm_max_tokens = 256
+    server.llm_max_turns = 5
+
+    class DummyLLM:
+        async def chat(self, *args, **kwargs):
+            return {"choices": [{"message": {"content": "Wort " * 200}}]}
+
+    server.llm = DummyLLM()
+    server.chat_histories = {}
+    server._hist = lambda cid: server.chat_histories.setdefault(cid, [])
+    server._hist_trim = lambda cid: None
+
+    result = await server._ask_llm("c1", "hi")
+    assert result and len(result) <= 500
+

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -56,7 +56,7 @@ _PROJECT_ROOT = _P(__file__).resolve().parents[2]
  if str(_PROJECT_ROOT) not in _sys.path else None)
 # ------------------------------------------
 from ws_server.tts.manager import TTSManager, TTSEngineType, TTSConfig
-from ws_server.tts.staged_tts import StagedTTSProcessor
+from ws_server.tts.staged_tts import StagedTTSProcessor, _limit_and_chunk
 from ws_server.tts.staged_tts.staged_processor import StagedTTSConfig
 from ws_server.core.prompt import get_system_prompt
 from audio.vad import VoiceActivityDetector, VADConfig
@@ -1085,9 +1085,10 @@ class VoiceServer:
             msg = choice.get("message") or {}
             content = msg.get("content") or ""
             if content.strip():
-                msgs.append({"role": "assistant", "content": content})
+                capped = " ".join(_limit_and_chunk(content))
+                msgs.append({"role": "assistant", "content": capped})
                 self._hist_trim(client_id)
-                return content.strip()
+                return capped
         except Exception:
             logging.exception("LLM chat failed")
         return None

--- a/ws_server/core/config.py
+++ b/ws_server/core/config.py
@@ -42,9 +42,9 @@ DEFAULT_ENV: dict[str, str] = {
     "LLM_MAX_TURNS": "5",
     "LLM_TIMEOUT_SECONDS": "20",
     "LLM_SYSTEM_PROMPT": (
-        "You are a friendly voice assistant. Reply in short, natural sentences that "
-        "sound like speech. Avoid lists or Markdown formatting. If something is "
-        "unclear, ask a brief follow-up question."
+        "You are a friendly voice assistant. Answer in short, punctuated sentences "
+        "and keep responses under 500 characters. Avoid lists or Markdown formatting. "
+        "If something is unclear, ask a brief follow-up question."
     ),
 }
 


### PR DESCRIPTION
## Summary
- tighten default LLM system prompt for short, punctuated answers under 500 characters
- hard-cap LLM responses server-side via `_limit_and_chunk`
- cover prosody prompt and LLM cap with unit tests

## Testing
- `ruff check ws_server/core/config.py ws_server/compat/legacy_ws_server.py tests/unit/test_llm_prosody_prompt.py`
- `pytest tests/unit/test_llm_prosody_prompt.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8a642130483249db5d0e2c0bc24a2