### PR TITLE
sprint-14(ci): add lint/tests/hygiene gates; fail on duplicates or deprecated paths

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest ruff aiohttp prometheus-client websockets
+          pip install ruff pytest pytest-cov aiohttp prometheus-client websockets numpy python-dotenv
       - name: Repo hygiene
         run: python scripts/repo_hygiene.py --check
       - name: Lint
         run: ruff check ws_server backend/tts
       - name: Tests
-        run: python -m pytest -q
+        run: pytest -q

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -16,7 +16,7 @@ focused commit.
 - [x] Sprint 11 — Error handling & client resilience
 - [x] Sprint 12 — Model discovery & validation
 - [x] Sprint 13 — Configurable LLM prosody prompt
-- [ ] Sprint 14 — CI pipeline & "no duplicates" gate
+- [x] Sprint 14 — CI pipeline & "no duplicates" gate
 - [ ] Sprint 15 — Desktop playback sequencer polish
 - [ ] Sprint 16 — Docs & release notes
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 testpaths = tests
+addopts = --cov=ws_server --cov=backend --cov-fail-under=20


### PR DESCRIPTION
## Summary
- enforce coverage checks via pytest addopts
- extend server-ci to install test deps, run repo hygiene, lint, and tests
- mark sprint 14 as complete in refactor plan

## Testing
- `ruff check ws_server backend/tts`
- `pytest -q`
- `python scripts/repo_hygiene.py --check`


------
https://chatgpt.com/codex/tasks/task_e_68a8a82ef8e48324924b08dbf0cf8219