### PR TITLE
Add canonical TTS voice mapping with validation and tests

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -7,6 +7,9 @@ TTS_ENGINE=piper
 TTS_SPEED=1.0
 TTS_VOLUME=1.0
 TTS_MODEL_DIR=./models
+TTS_VOICE=de-thorsten-low
+TTS_TARGET_SR=24000
+TTS_LOUDNESS_NORMALIZE=0
 
 # === Zonos TTS ===
 TTS_ENGINE=zonos                  # optional: Standard-Engine

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,8 @@ Client applications (Electron Desktop, Android Cordova, Web GUI) connect to the 
 2. **Configuration:**
 
    * Copy `.env.example` → `.env`
-   * Important variables: `WS_HOST`, `WS_PORT`, `STT_MODEL`, `STT_DEVICE`, `TTS_ENGINE`
-   * Default values provided in `.env.defaults`
+   * Important variables: `WS_HOST`, `WS_PORT`, `STT_MODEL`, `STT_DEVICE`, `TTS_ENGINE`, `TTS_VOICE`
+   * Default values provided in `.env.defaults` (see `docs/TTS-VOICE-ALIASES.md` for voice mapping)
 
 3. **Run Backend:**
 

--- a/backend/tts/engine_zonos.py
+++ b/backend/tts/engine_zonos.py
@@ -123,7 +123,7 @@ class ZonosTTSEngine(BaseTTSEngine):
     async def synthesize(
         self,
         text: str,
-        voice: Optional[str] = None,
+        voice_id: Optional[str] = None,
         speed: Optional[float] = None,
         volume: Optional[float] = None,
         language: Optional[str] = None,
@@ -134,7 +134,7 @@ class ZonosTTSEngine(BaseTTSEngine):
             return TTSResult(success=False, audio_data=None, processing_time_ms=0.0, error_message="Zonos nicht initialisiert", engine_used="zonos")
 
         try:
-            voice = voice or self._active_voice
+            voice = voice_id or self._active_voice
             lang = _normalize_lang(language or self._active_lang or 'de')
 
             speaker_embed = None
@@ -189,7 +189,7 @@ class ZonosTTSEngine(BaseTTSEngine):
 
     async def test_synthesis(self, text: str = "Test der Sprachsynthese") -> TTSResult:
         """Kompatibel zum TTSManager.selftest"""
-        return await self.synthesize(text, voice=self._active_voice, language=self._active_lang)
+        return await self.synthesize(text, voice_id=self._active_voice, language=self._active_lang)
     
 
     def get_engine_info(self) -> dict:

--- a/backend/tts/kokoro_tts_engine.py
+++ b/backend/tts/kokoro_tts_engine.py
@@ -119,7 +119,7 @@ class KokoroTTSEngine(BaseTTSEngine):
             logger.error(f"Fehler beim Laden des Kokoro-Modells: {e}")
             raise TTSInitializationError(f"Kokoro-Modell konnte nicht geladen werden: {e}")
             
-    async def synthesize(self, text: str, voice: Optional[str] = None, **kwargs) -> TTSResult:
+    async def synthesize(self, text: str, voice_id: Optional[str] = None, **kwargs) -> TTSResult:
         """Synthesiere Text mit Kokoro TTS"""
         start_time = time.time()
         
@@ -137,7 +137,7 @@ class KokoroTTSEngine(BaseTTSEngine):
             await self.initialize()
             
         # Stimme bestimmen
-        target_voice = voice or self.config.voice
+        target_voice = voice_id or self.config.voice
         if not self.supports_voice(target_voice):
             # Fallback auf Standard-Stimme für Sprache
             lang = self.config.language.split('-')[0]

--- a/docs/TTS-VOICE-ALIASES.md
+++ b/docs/TTS-VOICE-ALIASES.md
@@ -1,0 +1,23 @@
+# Canonical TTS Voices
+
+The backend uses **canonical voice names** (e.g. `de-thorsten-low`) that map to engine-specific assets.
+Mappings live in `ws_server/tts/voice_aliases.py`.
+
+## Adding a Voice
+1. Choose a new canonical name.
+2. Add per-engine `EngineVoice` entries in `voice_aliases.py`.
+3. Point Piper to the `.onnx` model and set `voice_id` for Zonos/Kokoro.
+
+## Validation
+`validate_voice_assets()` checks that the assets exist and logs a summary at startup.
+Missing Piper models or voice IDs produce warnings.
+
+## Configuration
+Set the canonical name via `TTS_VOICE` in `.env` (defaults to `de-thorsten-low`).
+Optional post-processing:
+- `TTS_TARGET_SR` – resample to target sample rate (Hz).
+- `TTS_LOUDNESS_NORMALIZE` – set to `1` to normalize output gain.
+
+## Troubleshooting
+- "Piper model missing": ensure the `.onnx` file path is correct.
+- "Zonos/Kokoro disabled": add a mapping or adjust `TTS_VOICE`.

--- a/tests/integration/staged_tts_flow.py
+++ b/tests/integration/staged_tts_flow.py
@@ -8,7 +8,7 @@ from ws_server.tts.staged_tts.staged_processor import (
 
 
 class MockTTSManager:
-    async def synthesize(self, text, engine=None):
+    async def synthesize(self, text, engine=None, voice=None):
         await asyncio.sleep(0.01 if engine == "piper" else 0.02)
 
         class Result:
@@ -19,6 +19,9 @@ class MockTTSManager:
 
         return Result()
 
+    def engine_allowed_for_voice(self, engine, voice):
+        return True
+
 
 def test_staged_tts_flow():
     """Ensure staged TTS returns intro and main chunks with sequence end."""
@@ -26,7 +29,8 @@ def test_staged_tts_flow():
     start = time.time()
     chunks = asyncio.run(
         processor.process_staged_tts(
-            "Hallo Welt. Dies ist ein Test fuer das Staged TTS System."
+            "Hallo Welt. Dies ist ein Test fuer das Staged TTS System.",
+            "de-thorsten-low",
         )
     )
     duration = time.time() - start

--- a/tests/unit/test_staged_tts_fallback.py
+++ b/tests/unit/test_staged_tts_fallback.py
@@ -6,23 +6,28 @@ from ws_server.metrics.collector import collector
 class OnlyPiperManager:
     engines = {"piper": object()}
 
-    async def synthesize(self, text, engine=None):
+    async def synthesize(self, text, engine=None, voice=None):
         if engine != "piper":
             raise ValueError("engine not available")
+
         class R:
             success = True
             audio_data = b"x"
             engine_used = engine
             error_message = None
+
         await asyncio.sleep(0)
         return R()
+
+    def engine_allowed_for_voice(self, engine, voice):
+        return engine == "piper"
 
 
 def test_fallback_to_piper_only():
     collector.tts_engine_unavailable_total.labels(engine="zonos")._value.set(0)
     collector.tts_chunk_emitted_total.labels(engine="piper")._value.set(0)
     proc = StagedTTSProcessor(OnlyPiperManager(), StagedTTSConfig(max_chunks=3))
-    chunks = asyncio.run(proc.process_staged_tts("Hallo Welt. Noch ein Satz."))
+    chunks = asyncio.run(proc.process_staged_tts("Hallo Welt. Noch ein Satz.", "de-thorsten-low"))
     assert len(chunks) == 1
     assert chunks[0].engine == "piper"
     proc.create_chunk_message(chunks[0])
@@ -33,7 +38,7 @@ def test_fallback_to_piper_only():
 class TimeoutManager:
     engines = {"piper": object(), "zonos": object()}
 
-    async def synthesize(self, text, engine=None):
+    async def synthesize(self, text, engine=None, voice=None):
         class R:
             success = True
             audio_data = b"x"
@@ -47,6 +52,9 @@ class TimeoutManager:
             await asyncio.sleep(0.2)
             return R()
 
+    def engine_allowed_for_voice(self, engine, voice):
+        return True
+
 
 def test_timeout_counts_metric():
     collector.tts_sequence_timeout_total.labels(engine="zonos")._value.set(0)
@@ -56,7 +64,7 @@ def test_timeout_counts_metric():
         StagedTTSConfig(chunk_timeout_seconds=0.05, max_chunks=2),
     )
     text = "Hallo Welt. Noch ein Satz. " * 5
-    chunks = asyncio.run(proc.process_staged_tts(text))
+    chunks = asyncio.run(proc.process_staged_tts(text, "de-thorsten-low"))
     # Only piper chunk succeeded
     assert any(c.engine == "piper" for c in chunks)
     assert any(c.engine == "zonos" and not c.success for c in chunks)

--- a/testsuite/test_tts/test_staged_same_voice.py
+++ b/testsuite/test_tts/test_staged_same_voice.py
@@ -1,0 +1,44 @@
+import asyncio
+
+from ws_server.tts.staged_tts.staged_processor import StagedTTSProcessor, StagedTTSConfig
+
+
+class DummyManager:
+    def __init__(self, allow_zonos: bool):
+        self.allow_zonos = allow_zonos
+        self.calls = []
+        self.engines = {"piper": object()}
+        if allow_zonos:
+            self.engines["zonos"] = object()
+
+    def engine_allowed_for_voice(self, engine: str, voice: str) -> bool:
+        return engine != "zonos" or self.allow_zonos
+
+    async def synthesize(self, text, engine=None, voice=None):
+        self.calls.append((engine, voice))
+        class R:
+            success = True
+            audio_data = b"x"
+            engine_used = engine
+            error_message = None
+        return R()
+
+
+def test_staged_uses_same_voice():
+    mgr = DummyManager(allow_zonos=True)
+    proc = StagedTTSProcessor(mgr, StagedTTSConfig())
+    text = "Hallo Welt. Noch ein Satz. " * 5
+    asyncio.run(proc.process_staged_tts(text, "de-thorsten-low"))
+    voices = {v for _, v in mgr.calls}
+    assert voices == {"de-thorsten-low"}
+    engines = {e for e, _ in mgr.calls}
+    assert "piper" in engines and "zonos" in engines
+
+
+def test_staged_skips_unmapped_engine():
+    mgr = DummyManager(allow_zonos=False)
+    proc = StagedTTSProcessor(mgr, StagedTTSConfig())
+    text = "Hallo Welt. Noch ein Satz. " * 5
+    asyncio.run(proc.process_staged_tts(text, "de-thorsten-low"))
+    engines = {e for e, _ in mgr.calls}
+    assert engines == {"piper"}

--- a/testsuite/test_tts/test_validation.py
+++ b/testsuite/test_tts/test_validation.py
@@ -1,0 +1,17 @@
+import dataclasses
+from pathlib import Path
+
+from ws_server.tts.voice_aliases import VOICE_ALIASES, EngineVoice
+from ws_server.tts.voice_validation import validate_voice_assets
+
+
+def test_missing_piper_model(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.onnx"
+    ev = VOICE_ALIASES["de-thorsten-low"]["piper"]
+    monkeypatch.setitem(
+        VOICE_ALIASES["de-thorsten-low"],
+        "piper",
+        dataclasses.replace(ev, model_path=str(missing)),
+    )
+    msgs = validate_voice_assets("de-thorsten-low")
+    assert any("Piper model missing" in m for m in msgs)

--- a/testsuite/test_tts/test_voice_alias_resolution.py
+++ b/testsuite/test_tts/test_voice_alias_resolution.py
@@ -1,0 +1,17 @@
+import pytest
+
+from backend.tts.tts_manager import TTSManager
+
+
+def test_resolve_known_engines():
+    mgr = TTSManager()
+    ev_piper = mgr._resolve_engine_voice("piper", "de-thorsten-low")
+    assert ev_piper.model_path.endswith("de_DE-thorsten-low.onnx")
+    ev_zonos = mgr._resolve_engine_voice("zonos", "de-thorsten-low")
+    assert ev_zonos.voice_id == "thorsten"
+
+
+def test_missing_engine_mapping_raises():
+    mgr = TTSManager()
+    with pytest.raises(ValueError):
+        mgr._resolve_engine_voice("kokoro", "de-thorsten-low")

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -56,6 +56,7 @@ _PROJECT_ROOT = _P(__file__).resolve().parents[2]
  if str(_PROJECT_ROOT) not in _sys.path else None)
 # ------------------------------------------
 from ws_server.tts.manager import TTSManager, TTSEngineType, TTSConfig
+from ws_server.tts.voice_validation import validate_voice_assets
 from ws_server.tts.staged_tts import StagedTTSProcessor, _limit_and_chunk
 from ws_server.tts.staged_tts.staged_processor import StagedTTSConfig
 from ws_server.core.prompt import get_system_prompt
@@ -872,6 +873,9 @@ class VoiceServer:
         try:
             self.tts_manager = TTSManager()
             logger.info("✅ TTSManager created successfully")
+            canonical_voice = os.getenv("TTS_VOICE", "de-thorsten-low")
+            for msg in validate_voice_assets(canonical_voice):
+                logger.info(msg)
         except Exception as e:
             logger.error(f"❌ TTSManager creation failed: {e}")
             # Create dummy TTS manager for testing
@@ -1420,7 +1424,8 @@ class VoiceServer:
         sequence_id = None
         try:
             # Process with staged TTS
-            chunks = await self.staged_tts.process_staged_tts(response_text)
+            canonical_voice = os.getenv("TTS_VOICE", "de-thorsten-low")
+            chunks = await self.staged_tts.process_staged_tts(response_text, canonical_voice)
 
             if not chunks:
                 logger.warning("Staged TTS erzeugte keine Chunks")

--- a/ws_server/tts/__init__.py
+++ b/ws_server/tts/__init__.py
@@ -1,7 +1,17 @@
 """Text-to-Speech utilities and engine exports."""
 
+from .voice_aliases import VOICE_ALIASES, EngineVoice
+from .voice_validation import validate_voice_assets
+
 try:  # pragma: no cover - optional dependencies may be missing
     from .manager import TTSManager, TTSConfig, TTSEngineType
-    __all__ = ["TTSManager", "TTSConfig", "TTSEngineType"]
-except Exception:  # pragma: no cover - expose empty API if manager unavailable
-    __all__: list[str] = []
+    __all__ = [
+        "TTSManager",
+        "TTSConfig",
+        "TTSEngineType",
+        "VOICE_ALIASES",
+        "EngineVoice",
+        "validate_voice_assets",
+    ]
+except Exception:  # pragma: no cover - expose minimal API if manager unavailable
+    __all__ = ["VOICE_ALIASES", "EngineVoice", "validate_voice_assets"]

--- a/ws_server/tts/voice_aliases.py
+++ b/ws_server/tts/voice_aliases.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Optional, Dict
+
+
+@dataclass(frozen=True)
+class EngineVoice:
+    voice_id: Optional[str] = None
+    model_path: Optional[str] = None
+    language: Optional[str] = None
+    sample_rate: Optional[int] = None
+
+
+VOICE_ALIASES: Dict[str, Dict[str, EngineVoice]] = {
+    "de-thorsten-low": {
+        "piper": EngineVoice(
+            model_path="models/piper/de_DE-thorsten-low.onnx",
+            language="de",
+            sample_rate=22050,
+        ),
+        "zonos": EngineVoice(
+            voice_id="thorsten",
+            language="de",
+            sample_rate=48000,
+        ),
+        # Only include kokoro mapping if you really have a German voice that matches the timbre.
+        # "kokoro": EngineVoice(voice_id="de_sarah", language="de", sample_rate=24000),
+    },
+}

--- a/ws_server/tts/voice_validation.py
+++ b/ws_server/tts/voice_validation.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from typing import List
+from .voice_aliases import VOICE_ALIASES
+
+
+def validate_voice_assets(canonical_voice: str) -> List[str]:
+    messages: List[str] = []
+    mapping = VOICE_ALIASES.get(canonical_voice)
+    if not mapping:
+        return [f"❌ Voice mapping missing for '{canonical_voice}'"]
+
+    parts: List[str] = []
+    for engine in ["piper", "zonos", "kokoro"]:
+        ev = mapping.get(engine)
+        if not ev:
+            messages.append(f"⚠️ {engine.title()} disabled for '{canonical_voice}' (no mapping)")
+            continue
+        if engine == "piper":
+            if ev.model_path and Path(ev.model_path).exists():
+                parts.append(f"Piper[{ev.model_path}]")
+            else:
+                messages.append(f"❌ Piper model missing: {ev.model_path}")
+        else:
+            if ev.voice_id:
+                parts.append(f"{engine.title()}[{ev.voice_id}]")
+            else:
+                messages.append(
+                    f"⚠️ {engine.title()} disabled for '{canonical_voice}' (missing voice_id)"
+                )
+    if parts:
+        messages.insert(0, f"✅ Voice mapping: canonical='{canonical_voice}' → {', '.join(parts)}")
+    return messages


### PR DESCRIPTION
## Summary
- Introduce central canonical voice alias table and expose validation utilities
- Resolve voices per engine in TTSManager with optional prosody normalization
- Ensure staged TTS reuses the same canonical voice and skip unmapped engines
- Validate voice assets on startup and document canonical voice workflow
- Add comprehensive tests for alias resolution, staged flow, and asset validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b043011c832490e7de46733ddf96