### PR TITLE
fix: retain local Piper model path during initialization

### DIFF
--- a/backend/tts/piper_tts_engine.py
+++ b/backend/tts/piper_tts_engine.py
@@ -104,7 +104,11 @@ class PiperTTSEngine(BaseTTSEngine):
                     log.info(f"Piper: benutze lokales Modell: {onnx}")
                     self.model_path = onnx
                     self.config_path = js
+                    # Ensure config uses resolved model
+                    self.config.model_path = onnx
+                    self.config.voice = name
                     self.voice_ready = True
+                    self.is_initialized = True
                     # Früh raus – Rest der Init überspringen
                     return True
         log.warning("Piper: kein lokales Modell gefunden; geprüft:")
@@ -134,7 +138,10 @@ class PiperTTSEngine(BaseTTSEngine):
                 logger.info(f"Piper: benutze lokales Modell: {onnx}")
                 self.model_path = onnx
                 self.config_path = js
+                self.config.model_path = onnx
+                self.config.voice = voice
                 self.voice_ready = True
+                self.is_initialized = True
                 return True
         # --- END local model fallback ---
         """Initialisiere Piper TTS Engine"""

--- a/tests/unit/test_piper_model_resolution.py
+++ b/tests/unit/test_piper_model_resolution.py
@@ -1,0 +1,41 @@
+import types
+import pytest
+
+# Provide a minimal stub for the optional 'piper' dependency
+class _DummyVoice:
+    config = types.SimpleNamespace(sample_rate=22050)
+    def synthesize(self, text, syn_config=None):
+        yield types.SimpleNamespace(audio_int16_bytes=b"")
+
+class _DummyPiperVoice:
+    @staticmethod
+    def load(path):
+        return _DummyVoice()
+
+sys_modules = {
+    "piper": types.SimpleNamespace(PiperVoice=_DummyPiperVoice, SynthesisConfig=object)
+}
+
+# Inject stub into sys.modules before importing engine
+import sys
+sys.modules.update(sys_modules)
+
+from backend.tts.piper_tts_engine import PiperTTSEngine
+from backend.tts.base_tts_engine import TTSConfig
+
+
+def test_piper_initialization_uses_local_model(tmp_path, monkeypatch):
+    piper_dir = tmp_path / "piper"
+    piper_dir.mkdir()
+    model_file = piper_dir / "de-thorsten-low.onnx"
+    config_file = piper_dir / "de-thorsten-low.onnx.json"
+    model_file.write_bytes(b"")
+    config_file.write_text("{}")
+
+    monkeypatch.setenv("TTS_MODEL_DIR", str(tmp_path))
+    config = TTSConfig(engine_type="piper", voice="de-thorsten-low", model_dir=str(tmp_path))
+    engine = PiperTTSEngine(config)
+
+    import asyncio
+    assert asyncio.run(engine.initialize())
+    assert engine.config.model_path == str(model_file)


### PR DESCRIPTION
## Summary
- ensure Piper TTS initialization keeps resolved model path and voice in configuration
- add regression test for Piper local model resolution

## Testing
- `PYTEST_ADDOPTS="--no-cov" pytest tests/unit/test_piper_model_resolution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b6a11d888324ad67c53bd4c85cfe