### PR TITLE
Fix Piper model path resolution

### DIFF
--- a/backend/tts/piper_tts_engine.py
+++ b/backend/tts/piper_tts_engine.py
@@ -88,12 +88,15 @@ class PiperTTSEngine(BaseTTSEngine):
         ]))
         # Mögliche Basisverzeichnisse (in Reihenfolge) sammeln
         bases = []
+        project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
         for envk in ("TTS_MODEL_DIR", "MODELS_DIR"):
             v = os.getenv(envk)
             if v:
+                if not os.path.isabs(v):
+                    v = os.path.join(project_root, v)
                 bases.append(v)
         # Fallback: <repo>/models
-        bases.append(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "models"))
+        bases.append(os.path.join(project_root, "models"))
         tried = []
         for b in bases:
             for name in cand_names:
@@ -122,7 +125,11 @@ class PiperTTSEngine(BaseTTSEngine):
         import os
         import logging
         logger = logging.getLogger("backend.tts.piper_tts_engine")
-        base = os.getenv("TTS_MODEL_DIR") or os.getenv("MODELS_DIR") or os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "models")
+        env_base = os.getenv("TTS_MODEL_DIR") or os.getenv("MODELS_DIR") or "models"
+        if not os.path.isabs(env_base):
+            base = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), env_base)
+        else:
+            base = env_base
         voice = (os.getenv("TTS_VOICE") or "").strip()
         def _resolve_local_files(v):
             names = [v, v.replace("de_DE-", "de-"), v.replace("de-", "de_DE-")]

--- a/tests/unit/test_piper_model_resolution.py
+++ b/tests/unit/test_piper_model_resolution.py
@@ -1,41 +1,22 @@
-import types
-import pytest
-
-# Provide a minimal stub for the optional 'piper' dependency
-class _DummyVoice:
-    config = types.SimpleNamespace(sample_rate=22050)
-    def synthesize(self, text, syn_config=None):
-        yield types.SimpleNamespace(audio_int16_bytes=b"")
-
-class _DummyPiperVoice:
-    @staticmethod
-    def load(path):
-        return _DummyVoice()
-
-sys_modules = {
-    "piper": types.SimpleNamespace(PiperVoice=_DummyPiperVoice, SynthesisConfig=object)
-}
-
-# Inject stub into sys.modules before importing engine
-import sys
-sys.modules.update(sys_modules)
+import os
+import asyncio
+from pathlib import Path
 
 from backend.tts.piper_tts_engine import PiperTTSEngine
 from backend.tts.base_tts_engine import TTSConfig
 
 
-def test_piper_initialization_uses_local_model(tmp_path, monkeypatch):
-    piper_dir = tmp_path / "piper"
-    piper_dir.mkdir()
-    model_file = piper_dir / "de-thorsten-low.onnx"
-    config_file = piper_dir / "de-thorsten-low.onnx.json"
-    model_file.write_bytes(b"")
-    config_file.write_text("{}")
+def test_initialize_with_relative_models_dir(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    models_dir = tmp_path / "alt_models" / "piper"
+    models_dir.mkdir(parents=True)
+    (models_dir / "de-thorsten-low.onnx").write_bytes(b"0")
+    (models_dir / "de-thorsten-low.onnx.json").write_text("{}")
 
-    monkeypatch.setenv("TTS_MODEL_DIR", str(tmp_path))
-    config = TTSConfig(engine_type="piper", voice="de-thorsten-low", model_dir=str(tmp_path))
-    engine = PiperTTSEngine(config)
+    rel_path = os.path.relpath(models_dir.parent, start=repo_root)
+    monkeypatch.setenv("MODELS_DIR", rel_path)
 
-    import asyncio
-    assert asyncio.run(engine.initialize())
-    assert engine.config.model_path == str(model_file)
+    cfg = TTSConfig(engine_type="piper", voice="de-thorsten-low")
+    engine = PiperTTSEngine(cfg)
+    assert asyncio.run(engine.initialize()) is True
+    assert Path(engine.model_path).resolve() == (models_dir / "de-thorsten-low.onnx").resolve()


### PR DESCRIPTION
## Summary
- resolve relative TTS_MODEL_DIR/MODELS_DIR paths against project root so Piper models load reliably
- test Piper initialization when MODELS_DIR is relative

## Testing
- `pytest tests/unit test/test_piper.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8b82b9f8083249fc012156928eb6a