### PR TITLE
Fixe Piper Modellpfad

### DIFF
--- a/ws_server/tts/voice_aliases.py
+++ b/ws_server/tts/voice_aliases.py
@@ -13,7 +13,7 @@ class EngineVoice:
 VOICE_ALIASES: Dict[str, Dict[str, EngineVoice]] = {
     "de-thorsten-low": {
         "piper": EngineVoice(
-            model_path="models/piper/de_DE-thorsten-low.onnx",
+            model_path="models/piper/de-thorsten-low.onnx",
             language="de",
             sample_rate=22050,
         ),


### PR DESCRIPTION
## Summary
- korrigiere Voice-Alias für Piper, nutzt nun das tatsächliche Thorsten-Modell

## Testing
- `pytest tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68a8b9ddd80483248ae582a262419f3d