### PR TITLE
Add legacy audio import compatibility

### DIFF
--- a/audio/__init__.py
+++ b/audio/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility alias for legacy `audio` imports.
+
+This package mirrors `ws_server.audio` so that older modules
+expecting `audio.vad` continue to function.
+"""
+
+from ws_server.audio import *  # noqa: F401,F403

--- a/audio/vad.py
+++ b/audio/vad.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for `audio.vad`.
+
+Re-exports the VAD classes from `ws_server.audio.vad`.
+"""
+
+from ws_server.audio.vad import *  # noqa: F401,F403

--- a/tests/unit/test_vad_import.py
+++ b/tests/unit/test_vad_import.py
@@ -5,3 +5,10 @@ def test_vad_module_available():
     module = importlib.import_module("ws_server.audio.vad")
     assert hasattr(module, "VoiceActivityDetector")
     assert hasattr(module, "VADConfig")
+
+
+def test_legacy_audio_alias():
+    alias = importlib.import_module("audio.vad")
+    original = importlib.import_module("ws_server.audio.vad")
+    assert alias.VoiceActivityDetector is original.VoiceActivityDetector
+    assert alias.VADConfig is original.VADConfig


### PR DESCRIPTION
## Summary
- add `audio` package that forwards to `ws_server.audio`
- cover alias with unit tests

## Testing
- `pytest tests/unit/test_vad_import.py -q` *(fails: Required test coverage of 20% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dab6aaec8324ad0462803142ba26