### PR TITLE
Add locale voice alias for German Thorsten voice

### DIFF
--- a/docs/TTS-VOICE-ALIASES.md
+++ b/docs/TTS-VOICE-ALIASES.md
@@ -3,6 +3,11 @@
 The backend uses **canonical voice names** (e.g. `de-thorsten-low`) that map to engine-specific assets.
 Mappings live in `ws_server/tts/voice_aliases.py`.
 
+## Available Voices
+
+- `de-thorsten-low` – German male voice (Piper: `models/piper/de-thorsten-low.onnx`, Zonos: `thorsten`)
+- `de_DE-thorsten-low` – locale-style alias for `de-thorsten-low`
+
 ## Adding a Voice
 1. Choose a new canonical name.
 2. Add per-engine `EngineVoice` entries in `voice_aliases.py`.

--- a/ws_server/tts/voice_aliases.py
+++ b/ws_server/tts/voice_aliases.py
@@ -25,4 +25,17 @@ VOICE_ALIASES: Dict[str, Dict[str, EngineVoice]] = {
         # Only include kokoro mapping if you really have a German voice that matches the timbre.
         # "kokoro": EngineVoice(voice_id="de_sarah", language="de", sample_rate=24000),
     },
+    # Alias with locale-style name for compatibility
+    "de_DE-thorsten-low": {
+        "piper": EngineVoice(
+            model_path="models/piper/de-thorsten-low.onnx",
+            language="de",
+            sample_rate=22050,
+        ),
+        "zonos": EngineVoice(
+            voice_id="thorsten",
+            language="de",
+            sample_rate=48000,
+        ),
+    },
 }


### PR DESCRIPTION
## Summary
- add `de_DE-thorsten-low` alias mapping for Piper and Zonos
- document available TTS voices and new alias

## Testing
- `pytest tests/unit` *(fails: audio.vad alias mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dd6032788324847b0f19cba9b15f