### PR TITLE
fix: resolve staged TTS chunking errors

### DIFF
--- a/tests/unit/test_optimize_for_prosody.py
+++ b/tests/unit/test_optimize_for_prosody.py
@@ -1,0 +1,5 @@
+from ws_server.tts.staged_tts.chunking import optimize_for_prosody
+
+
+def test_optimize_for_prosody_removes_diacritics():
+    assert optimize_for_prosody('façade') == 'facade.'

--- a/ws_server/tts/staged_tts/chunking.py
+++ b/ws_server/tts/staged_tts/chunking.py
@@ -3,6 +3,7 @@ Text-Chunking für sprechgerechte TTS-Ausgabe
 """
 
 import re
+import unicodedata
 from typing import List
 
 def sanitize_for_tts(text: str) -> str:
@@ -130,17 +131,16 @@ def create_intro_chunk(chunks: List[str], max_intro_length: int = 120) -> tuple[
 
 
 def optimize_for_prosody(text: str) -> str:
-    text = sanitize_for_tts(text)
-    """
-    Optimiere Text für natürliche TTS-Prosodie.
-    
+    """Optimiere Text für natürliche TTS-Prosodie.
+
     Args:
         text: Eingabetext
-    
+
     Returns:
         Optimierter Text mit besserer Zeichensetzung
     """
     text = sanitize_for_tts(text)
+
     # Zahlen in Wortform umwandeln (vereinfacht)
     number_replacements = {
         '20.000': 'zwanzigtausend',
@@ -148,7 +148,8 @@ def optimize_for_prosody(text: str) -> str:
         '2.000': 'zweitausend',
         '10.000': 'zehntausend',
         '100.000': 'hunderttausend',
-    
+    }
+
     # HARDCORE FIX: Cedilla und alle diakritischen Zeichen entfernen
     text = ''.join(
         char for char in unicodedata.normalize('NFD', text)
@@ -156,8 +157,7 @@ def optimize_for_prosody(text: str) -> str:
     )
     # Spezielle Behandlung für Cedilla
     text = text.replace(chr(0x0327), '')  # Combining cedilla
-    }
-    
+
     result = text
     for num, word in number_replacements.items():
         result = result.replace(num, word)
@@ -169,10 +169,10 @@ def optimize_for_prosody(text: str) -> str:
 
     # Entferne redundante Leerzeichen
     result = re.sub(r'\s+', ' ', result)
-    
+
     # Stelle sicher, dass Sätze mit Punkt enden
     result = result.strip()
     if result and result[-1] not in '.!?':
         result += '.'
-    
+
     return result

--- a/ws_server/tts/staged_tts/staged_processor.py
+++ b/ws_server/tts/staged_tts/staged_processor.py
@@ -18,8 +18,6 @@ from ws_server.metrics.collector import collector
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-
 def _hardcore_sanitize_text(text: str) -> str:
     """Entfernt ALLE problematischen Zeichen für Piper TTS"""
     if not text:
@@ -60,6 +58,7 @@ def _hardcore_sanitize_text(text: str) -> str:
     return text
 
 
+@dataclass
 class TTSChunk:
     """Repräsentiert einen TTS-Chunk mit Metadaten"""
     sequence_id: str


### PR DESCRIPTION
## Summary
- sanitize staged TTS chunking and prosody optimization
- declare TTSChunk as dataclass
- cover diacritic cleanup in prosody optimizer test

## Testing
- `pytest tests/unit -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client'; AssertionError in test_staged_tts_fallback; AssertionError in test_legacy_audio_alias)*
- `python -m ws_server.cli --help`

------
https://chatgpt.com/codex/tasks/task_e_68a964e827cc83249bddad83eb1692e8