### PR TITLE
Sanitize text for Zonos TTS engine

### DIFF
--- a/backend/tts/engine_zonos.py
+++ b/backend/tts/engine_zonos.py
@@ -134,6 +134,18 @@ class ZonosTTSEngine(BaseTTSEngine):
             return TTSResult(success=False, audio_data=None, processing_time_ms=0.0, error_message="Zonos nicht initialisiert", engine_used="zonos")
 
         try:
+            # Text säubern – verhindert "Missing phoneme from id map"-Fehler
+            try:  # pragma: no cover - Import kann scheitern
+                from ws_server.tts.staged_tts.chunking import sanitize_for_tts
+                text = sanitize_for_tts(text)
+            except Exception:
+                pass
+            import unicodedata
+            text = unicodedata.normalize('NFD', text)
+            text = ''.join(ch for ch in text if unicodedata.category(ch) != 'Mn')
+            text = text.replace(chr(0x0327), '')
+            text = unicodedata.normalize('NFC', text)
+
             voice = voice_id or self._active_voice
             lang = _normalize_lang(language or self._active_lang or 'de')
 

--- a/tests/unit/test_zonos_text_sanitization.py
+++ b/tests/unit/test_zonos_text_sanitization.py
@@ -1,0 +1,43 @@
+import asyncio
+import contextlib
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from backend.tts.engine_zonos import ZonosTTSEngine
+from backend.tts.base_tts_engine import TTSConfig
+
+class DummyAutoencoder:
+    sampling_rate = 44100
+    def decode(self, codes):
+        return torch.zeros(1, 1, 10)
+
+class DummyModel:
+    autoencoder = DummyAutoencoder()
+    def prepare_conditioning(self, cond_dict):
+        return cond_dict
+    def generate(self, conditioning):
+        return torch.zeros(1, 10)
+    def parameters(self):
+        yield torch.zeros(1)
+
+
+def test_zonos_engine_sanitizes_text(monkeypatch):
+    captured = {}
+
+    async def run():
+        engine = ZonosTTSEngine(TTSConfig(voice="test", language="de"))
+        engine.model = DummyModel()
+        engine.device = "cpu"
+
+        def fake_make_cond_dict(*, text, language, speaker):
+            captured['text'] = text
+            return {}
+
+        monkeypatch.setattr("backend.tts.engine_zonos.make_cond_dict", fake_make_cond_dict)
+        monkeypatch.setattr("torch.autocast", lambda *a, **k: contextlib.nullcontext())
+
+        await engine.synthesize("Hallo ̧", voice_id="test")
+
+    asyncio.run(run())
+    assert '̧' not in captured['text']


### PR DESCRIPTION
## Summary
- sanitize input text in Zonos engine to strip diacritics and avoid missing phoneme errors
- add unit test for Zonos text sanitization (skips if torch unavailable)

## Testing
- `pytest tests/unit/test_zonos_text_sanitization.py -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68a96659440c83249811ae49aa6767cc