### PR TITLE
Sanitize spacing cedilla for Zonos TTS

### DIFF
--- a/backend/tts/engine_zonos.py
+++ b/backend/tts/engine_zonos.py
@@ -144,6 +144,7 @@ class ZonosTTSEngine(BaseTTSEngine):
             text = unicodedata.normalize('NFD', text)
             text = ''.join(ch for ch in text if unicodedata.category(ch) != 'Mn')
             text = text.replace(chr(0x0327), '')
+            text = text.replace(chr(0x00B8), '')
             text = unicodedata.normalize('NFC', text)
 
             voice = voice_id or self._active_voice

--- a/tests/unit/test_zonos_text_sanitization.py
+++ b/tests/unit/test_zonos_text_sanitization.py
@@ -7,22 +7,35 @@ torch = pytest.importorskip("torch")
 from backend.tts.engine_zonos import ZonosTTSEngine
 from backend.tts.base_tts_engine import TTSConfig
 
+
 class DummyAutoencoder:
     sampling_rate = 44100
+
     def decode(self, codes):
         return torch.zeros(1, 1, 10)
 
+
 class DummyModel:
     autoencoder = DummyAutoencoder()
+
     def prepare_conditioning(self, cond_dict):
         return cond_dict
+
     def generate(self, conditioning):
         return torch.zeros(1, 10)
+
     def parameters(self):
         yield torch.zeros(1)
 
 
-def test_zonos_engine_sanitizes_text(monkeypatch):
+@pytest.mark.parametrize(
+    "raw, forbidden",
+    [
+        ("Hallo ̧", "̧"),
+        ("Hallo \u00b8", "\u00b8"),
+    ],
+)
+def test_zonos_engine_sanitizes_text(monkeypatch, raw, forbidden):
     captured = {}
 
     async def run():
@@ -31,13 +44,13 @@ def test_zonos_engine_sanitizes_text(monkeypatch):
         engine.device = "cpu"
 
         def fake_make_cond_dict(*, text, language, speaker):
-            captured['text'] = text
+            captured["text"] = text
             return {}
 
         monkeypatch.setattr("backend.tts.engine_zonos.make_cond_dict", fake_make_cond_dict)
         monkeypatch.setattr("torch.autocast", lambda *a, **k: contextlib.nullcontext())
 
-        await engine.synthesize("Hallo ̧", voice_id="test")
+        await engine.synthesize(raw, voice_id="test")
 
     asyncio.run(run())
-    assert '̧' not in captured['text']
+    assert forbidden not in captured["text"]


### PR DESCRIPTION
## Summary
- strip spacing cedilla from Zonos input text to avoid phoneme lookup warnings
- extend sanitization test to cover spacing and combining cedillas

## Testing
- `pytest -q -o addopts="" tests/unit/test_zonos_text_sanitization.py` *(fails: skipped, torch missing)*


------
https://chatgpt.com/codex/tasks/task_e_68a96bccbd4883249240c93615c1e6b8