### PR TITLE
Wrap Cordova prepare script to avoid invalid exit codes

### DIFF
--- a/voice-assistant-apps/mobile/cordova-wrapper.js
+++ b/voice-assistant-apps/mobile/cordova-wrapper.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// Wrapper around Cordova CLI to ensure numeric exit codes
+require('loud-rejection/register');
+const util = require('util');
+const { events, CordovaError } = require('cordova-common');
+const cli = require('cordova/src/cli');
+
+cli(process.argv).catch(err => {
+  if (!(err instanceof Error)) {
+    const errorOutput = typeof err === 'string' ? err : util.inspect(err);
+    throw new CordovaError('Promise rejected with non-error: ' + errorOutput);
+  }
+  const code = typeof err.code === 'number' ? err.code : 1;
+  process.exitCode = code;
+  console.error(err.message);
+  events.emit('verbose', err.stack);
+});

--- a/voice-assistant-apps/mobile/package.json
+++ b/voice-assistant-apps/mobile/package.json
@@ -10,7 +10,7 @@
     "build": "cordova build android",
     "build-release": "cordova build android --release",
     "serve": "cordova serve",
-    "prepare": "cordova prepare android",
+    "prepare": "node cordova-wrapper.js prepare android",
     "emulate": "cordova emulate android",
     "device": "cordova run android --device",
     "clean": "cordova clean android",


### PR DESCRIPTION
## Summary
- add a local `cordova-wrapper.js` to normalize non-numeric exit codes from the Cordova CLI
- route the mobile app's `prepare` script through this wrapper

## Testing
- `npm run prepare` *(fails: Could not load API for android project /workspace/Sprachassistent/voice-assistant-apps/mobile/platforms/android/cordova/Api.js)*
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: No files matching the pattern "www/js/*.js" were found)*

------
https://chatgpt.com/codex/tasks/task_e_68a96e77dcc48324ae28b4ab0f073142