### PR TITLE
TTS/Piper: final guard strips combining marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Das System unterstützt jetzt flexibles Text-to-Speech mit Echtzeitwechsel zwisc
 - **Offline-Verarbeitung** ohne Cloud-Abhängigkeit
 - **ARM-optimiert** für Raspberry Pi
 - **Final guard** entfernt kombinierende Zeichen (U+0300–U+036F) vor der Synthese
+- **Debug**: `PIPELINE_DEBUG_SANITIZE=1` protokolliert entfernte Zeichen
 
 #### 🌍 Kokoro TTS (Mehrsprachig)
 - **Kompakte Engine** (~80MB quantisiert) mit schneller Inferenz

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -33,3 +33,4 @@
 ## Piper TTS sanitization
 - Text for Piper is sanitized with a final guard.
 - All combining marks (U+0300–U+036F) are removed before synthesis to prevent "Missing phoneme from id map" warnings.
+- Optional debug logging via `PIPELINE_DEBUG_SANITIZE=1` shows how many Zeichen entfernt wurden.

--- a/tests/unit/test_tts_manager_combining_guard.py
+++ b/tests/unit/test_tts_manager_combining_guard.py
@@ -1,0 +1,29 @@
+import unicodedata
+import pytest
+
+from backend.tts.tts_manager import TTSManager, TTSResult, COMBINING_GUARD_RE
+
+
+def test_combining_guard_regex_matches():
+    assert COMBINING_GUARD_RE.search("a\u0327")
+
+
+@pytest.mark.asyncio
+async def test_manager_strips_combining_before_engine():
+    manager = TTSManager()
+
+    class DummyEngine:
+        def __init__(self):
+            self.last_text = None
+
+        async def synthesize(self, text: str, *args, **kwargs):
+            self.last_text = text
+            return TTSResult(audio_data=b"", success=True, engine_used="piper")
+
+    dummy = DummyEngine()
+    manager.engines["piper"] = dummy
+    manager.default_engine = "piper"
+
+    await manager.synthesize("fa\u0327cade", engine="piper")
+    assert dummy.last_text == "facade"
+    assert all(unicodedata.category(ch) != "Mn" for ch in dummy.last_text)

--- a/ws_server/tts/text_sanitizer.py
+++ b/ws_server/tts/text_sanitizer.py
@@ -16,7 +16,7 @@ _TYPOMAP = {
     "\u2026": "...",
     "\u00A0": " ",
 }
-_COMBINING_RE = re.compile(r"[\u0300-\u036F]")
+_COMBINING_RE = re.compile(r"[̀-ͯ]")
 
 
 def sanitize_for_tts_strict(text: str) -> str:
@@ -49,7 +49,7 @@ def pre_clean_for_piper(text: str) -> str:
     t = _COMBINING_RE.sub("", t)
     if os.getenv("PIPELINE_DEBUG_SANITIZE") and t != original:
         removed = len(original) - len(t)
-        logger.debug("PIPELINE_SANITIZE removed=%d", removed)
+        logger.debug("PIPELINE_SANITIZE entfernt=%d", removed)
     return t
 
 


### PR DESCRIPTION
## Summary
- fix combining mark regex in sanitizer and TTS manager
- sanitize input before Piper at manager level
- document PIPELINE_DEBUG_SANITIZE and add regression tests

## Testing
- `pytest --no-cov tests/unit/test_pre_clean_for_piper.py tests/unit/test_tts_manager_combining_guard.py`

------
https://chatgpt.com/codex/tasks/task_e_68a98ae3567c8324a78501e932778017