### PR TITLE
feat: robust TTS pre-sanitizer and phoneme audit

### DIFF
--- a/docs/TTS-TROUBLESHOOTING.md
+++ b/docs/TTS-TROUBLESHOOTING.md
@@ -27,9 +27,9 @@ TTS_DROP_ORPHAN_COMBINING=true
 The warning *"Missing phoneme from id map"* usually stems from stray
 combining marks (for example the cedilla `\u0327`) or characters outside the
 model's alphabet. The pre-sanitizer now normalizes text (NFKC→NFD→NFC), drops
-or replaces unknown symbols and logs a warning instead of raising an error.
-Feeding texts like `façade`, `garçon`, `çedilla`, `übermäßig` or `naïve`
-no longer produces this warning.
+or replaces unknown symbols (e.g. `Ł`→`L`, `đ`→`d`) and logs a warning instead
+of raising an error. Feeding texts like `façade`, `garçon`, `çedilla`,
+`übermäßig`, `Łódź`, `İstanbul` or `naïve` no longer produces this warning.
 
 ## Fallback Strategy
 Unknown phonemes are dropped or mapped once per symbol with a warning. Logs stay readable and synthesis continues.

--- a/tests/test_sanitizer_phonemes.py
+++ b/tests/test_sanitizer_phonemes.py
@@ -26,7 +26,16 @@ def test_nbsp_zero_width_removed():
 def test_phoneme_coverage_subset():
     with open('tests/fixtures/de_DE-thorsten-low.onnx.json', encoding='utf-8') as f:
         model_set = set(json.load(f)['phoneme_id_map'].keys())
-    words = ["façade", "garçon", "çedilla", "übermäßig", "naïve"]
+    words = [
+        "façade",
+        "garçon",
+        "çedilla",
+        "übermäßig",
+        "naïve",
+        "Łódź",
+        "São Paulo",
+        "İstanbul",
+    ]
     for w in words:
         s = sanitize_for_tts(w)
         for ch in s:
@@ -34,8 +43,8 @@ def test_phoneme_coverage_subset():
                 assert ch in model_set
 
 
-def test_non_latin_removed():
-    raw = "東京"
+@pytest.mark.parametrize("raw", ["東京", "Москва"])
+def test_non_latin_removed(raw: str):
     assert sanitize_for_tts(raw) == ""
 
 

--- a/tools/tts/phoneme_audit.py
+++ b/tools/tts/phoneme_audit.py
@@ -15,6 +15,10 @@ PROBLEM_TEXTS = [
     "fa̧cade",
     "übermäßig",
     "naïve",
+    "Łódź",
+    "São Paulo",
+    "İstanbul",
+    "Москва",
     "東京",
 ]
 

--- a/ws_server/tts/staged_tts/chunking.py
+++ b/ws_server/tts/staged_tts/chunking.py
@@ -1,9 +1,8 @@
 """Text-Chunking und Sanitizing für sprechgerechte TTS-Ausgabe."""
 
 import re
-import unicodedata
 from typing import List
-from ws_server.tts.text_sanitizer import sanitize_for_tts_strict
+from ws_server.tts.text_sanitizer import sanitize_for_tts_strict, pre_clean_for_piper
 from ws_server.tts.text_normalize import sanitize_for_tts as sanitize_basic
 def _limit_and_chunk(text: str, max_length: int = 500) -> List[str]:
     """
@@ -16,11 +15,7 @@ def _limit_and_chunk(text: str, max_length: int = 500) -> List[str]:
     Returns:
         Liste von Text-Chunks (80-180 Zeichen pro Chunk)
     """
-    text = sanitize_for_tts_strict(sanitize_basic(text))
-    try:
-        text = unicodedata.normalize('NFC', text)
-    except Exception:
-        pass
+    text = pre_clean_for_piper(sanitize_basic(text))
     # Text begrenzen auf max_length
     text = text.strip()
     if len(text) > max_length:

--- a/ws_server/tts/text_sanitizer.py
+++ b/ws_server/tts/text_sanitizer.py
@@ -16,6 +16,13 @@ _TYPOMAP = {
     "\u2026": "...",
     "\u00A0": " ",
 }
+_FALLBACK_MAP = {
+    "ł": "l", "Ł": "L",
+    "đ": "d", "Đ": "D",
+    "ø": "o", "Ø": "O",
+    "ð": "d", "Ð": "D",
+}
+_FALLBACK_TRANSLATION = str.maketrans(_FALLBACK_MAP)
 _COMBINING_RE = re.compile(r"[̀-ͯ]")
 _ALLOWED = set("abcdefghijklmnopqrstuvwxyzäöüßABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜß0123456789 .,!?;:-'\"()")
 
@@ -32,6 +39,7 @@ def sanitize_for_tts_strict(text: str) -> str:
     t = unicodedata.normalize("NFD", t)
     t = "".join(ch for ch in t if unicodedata.category(ch) != "Mn")
     t = t.translate(str.maketrans(_TYPOMAP))
+    t = t.translate(_FALLBACK_TRANSLATION)
     cleaned: list[str] = []
     for ch in t:
         if ord(ch) > 127 and ch not in _ALLOWED:
@@ -55,6 +63,7 @@ def pre_clean_for_piper(text: str) -> str:
     t = sanitize_for_tts_strict(text)
     t = t.replace("\u0327", "")  # combining cedilla
     t = _COMBINING_RE.sub("", t)
+    t = unicodedata.normalize("NFC", t)
     if t != original:
         removed = len(original) - len(t)
         logger.warning("pre_clean_for_piper entfernte %d Zeichen", removed)


### PR DESCRIPTION
## Summary
- normalize and map extended Latin characters before phonemization
- chunk text via unified `pre_clean_for_piper` to drop combining marks
- audit and test extra unicode edge cases

## Testing
- `pytest tests/test_sanitizer_phonemes.py -q --cov=ws_server/tts/text_sanitizer.py --cov=ws_server/tts/text_normalize.py --cov=tools/tts/phoneme_audit.py --cov-fail-under=0`
- `pytest tests/unit/test_pre_clean_for_piper.py -q --cov=ws_server/tts/text_sanitizer.py --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68a99449dbd8832480cfd461b1eea633