### PR TITLE
fix: robuste Pre-Sanitizing-Kette

### DIFF
--- a/docs/TTS-TROUBLESHOOTING.md
+++ b/docs/TTS-TROUBLESHOOTING.md
@@ -26,10 +26,11 @@ TTS_DROP_ORPHAN_COMBINING=true
 
 The warning *"Missing phoneme from id map"* usually stems from stray
 combining marks (for example the cedilla `\u0327`) or characters outside the
-model's alphabet. The pre-sanitizer now normalizes text (NFKC→NFD→NFC), drops
-or replaces unknown symbols (e.g. `Ł`→`L`, `đ`→`d`) and logs a warning instead
-of raising an error. Feeding texts like `façade`, `garçon`, `çedilla`,
-`übermäßig`, `Łódź`, `İstanbul` or `naïve` no longer produces this warning.
+model's alphabet. The helper `pre_sanitize_text()` normalizes
+text (NFKC→NFD→NFC), removes combining marks, and maps or drops unknown
+symbols (e.g. `Ł`→`L`, `đ`→`d`). It logs a warning instead of raising an error.
+Feeding texts like `façade`, `garçon`, `çedilla`, `übermäßig`, `Łódź`,
+`İstanbul` or `naïve` no longer produces this warning.
 
 ## Fallback Strategy
 Unknown phonemes are dropped or mapped once per symbol with a warning. Logs stay readable and synthesis continues.

--- a/tests/test_sanitizer_phonemes.py
+++ b/tests/test_sanitizer_phonemes.py
@@ -3,7 +3,8 @@ import unicodedata
 import logging
 import pytest
 from ws_server.tts.text_normalize import sanitize_for_tts
-from ws_server.tts.text_sanitizer import sanitize_for_tts_strict
+from ws_server.tts.text_sanitizer import sanitize_for_tts_strict, pre_sanitize_text
+from ws_server.tts.staged_tts.chunking import _limit_and_chunk
 from tools.tts.phoneme_audit import PROBLEM_TEXTS, load_map, audit_texts
 
 
@@ -61,3 +62,12 @@ def test_strict_sanitizer_warns_and_cleans(caplog):
     cleaned = sanitize_for_tts_strict("çedilla ☃")
     assert cleaned == "cedilla"
     assert "unbekanntes Zeichen" in caplog.text
+
+
+def test_pre_sanitize_text_handles_combining():
+    assert pre_sanitize_text("çedilla") == "cedilla"
+
+
+def test_chunking_pre_sanitizes():
+    chunks = _limit_and_chunk("naïve çedilla")
+    assert chunks == ["naive cedilla"]

--- a/tools/tts/phoneme_audit.py
+++ b/tools/tts/phoneme_audit.py
@@ -20,6 +20,8 @@ PROBLEM_TEXTS = [
     "İstanbul",
     "Москва",
     "東京",
+    "Crème brûlée",
+    "¿Qué?",
 ]
 
 def load_map(path: str) -> set[str]:

--- a/ws_server/tts/staged_tts/chunking.py
+++ b/ws_server/tts/staged_tts/chunking.py
@@ -2,8 +2,10 @@
 
 import re
 from typing import List
-from ws_server.tts.text_sanitizer import sanitize_for_tts_strict, pre_clean_for_piper
-from ws_server.tts.text_normalize import sanitize_for_tts as sanitize_basic
+from ws_server.tts.text_sanitizer import (
+    sanitize_for_tts_strict,
+    pre_sanitize_text,
+)
 def _limit_and_chunk(text: str, max_length: int = 500) -> List[str]:
     """
     Begrenze und segmentiere Text für staged TTS.
@@ -15,7 +17,7 @@ def _limit_and_chunk(text: str, max_length: int = 500) -> List[str]:
     Returns:
         Liste von Text-Chunks (80-180 Zeichen pro Chunk)
     """
-    text = pre_clean_for_piper(sanitize_basic(text))
+    text = pre_sanitize_text(text)
     # Text begrenzen auf max_length
     text = text.strip()
     if len(text) > max_length:

--- a/ws_server/tts/text_sanitizer.py
+++ b/ws_server/tts/text_sanitizer.py
@@ -7,6 +7,8 @@ import unicodedata
 import logging
 from typing import Dict
 
+from .text_normalize import sanitize_for_tts as _basic_sanitize
+
 logger = logging.getLogger(__name__)
 
 _TYPOMAP = {
@@ -69,6 +71,19 @@ def pre_clean_for_piper(text: str) -> str:
         logger.warning("pre_clean_for_piper entfernte %d Zeichen", removed)
     return t
 
+
+def pre_sanitize_text(text: str) -> str:
+    """Run basic + strict sanitizers and log removed characters."""
+    if not text:
+        return text
+    analysis = analyze_problematic_chars(text)
+    cleaned = pre_clean_for_piper(_basic_sanitize(text))
+    if analysis.get("count"):
+        logger.warning(
+            "pre_sanitize_text entfernte %d Zeichen: %s",
+            analysis["count"], " ".join(analysis["unique"]),
+        )
+    return cleaned
 
 def analyze_problematic_chars(text: str) -> Dict[str, any]:
     """Return a summary of non-ASCII or combining characters."""


### PR DESCRIPTION
## Summary
- combine basic and strict text cleaning in new `pre_sanitize_text`
- ensure staged chunking runs through pre-sanitizer
- extend phoneme audit and unicode sanitiser tests
- document missing-phoneme warning with new helper

## Testing
- `pytest tests/test_sanitizer_phonemes.py --cov-fail-under=0`
- `python tools/tts/phoneme_audit.py tests/fixtures/de_DE-thorsten-low.onnx.json de` *(fails: phonemizer not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a9971f5fec83248781628d98a1743a