### PR TITLE
Robuste Sanitizing-Pipeline verhindert fehlende Phoneme

### DIFF
--- a/docs/TTS-TROUBLESHOOTING.md
+++ b/docs/TTS-TROUBLESHOOTING.md
@@ -28,9 +28,10 @@ The warning *"Missing phoneme from id map"* usually stems from stray
 combining marks (for example the cedilla `\u0327`) or characters outside the
 model's alphabet. The helper `pre_sanitize_text()` normalizes
 text (NFKC→NFD→NFC), removes combining marks, and maps or drops unknown
-symbols (e.g. `Ł`→`L`, `đ`→`d`). It logs a warning instead of raising an error.
-Feeding texts like `façade`, `garçon`, `çedilla`, `übermäßig`, `Łódź`,
-`İstanbul` or `naïve` no longer produces this warning.
+symbols (e.g. `Ł`→`L`, `đ`→`d`). Unsupported ASCII symbols like `%` or `$`
+are stripped as well. Every removal triggers a warning instead of raising an
+error. Feeding texts like `façade`, `garçon`, `çedilla`, `übermäßig`,
+`Łódź`, `İstanbul` or `naïve` no longer produces this warning.
 
 ## Fallback Strategy
 Unknown phonemes are dropped or mapped once per symbol with a warning. Logs stay readable and synthesis continues.

--- a/tests/test_sanitizer_phonemes.py
+++ b/tests/test_sanitizer_phonemes.py
@@ -71,3 +71,16 @@ def test_pre_sanitize_text_handles_combining():
 def test_chunking_pre_sanitizes():
     chunks = _limit_and_chunk("naïve çedilla")
     assert chunks == ["naive cedilla"]
+
+
+def test_strict_sanitizer_strips_ascii(caplog):
+    caplog.set_level(logging.WARNING)
+    cleaned = sanitize_for_tts_strict("foo% bar$")
+    assert cleaned == "foo bar"
+    assert "%" not in cleaned and "$" not in cleaned
+    assert "unbekanntes Zeichen" in caplog.text
+
+
+def test_chunking_drops_ascii():
+    chunks = _limit_and_chunk("test% chunk$")
+    assert chunks == ["test chunk"]

--- a/tools/tts/phoneme_audit.py
+++ b/tools/tts/phoneme_audit.py
@@ -11,6 +11,7 @@ except Exception:  # pragma: no cover - optional dep
 PROBLEM_TEXTS = [
     "façade",
     "garçon",
+    "gaŗçon",
     "çedilla",
     "fa̧cade",
     "übermäßig",

--- a/ws_server/tts/staged_tts/chunking.py
+++ b/ws_server/tts/staged_tts/chunking.py
@@ -1,6 +1,7 @@
 """Text-Chunking und Sanitizing für sprechgerechte TTS-Ausgabe."""
 
 import re
+import unicodedata
 from typing import List
 from ws_server.tts.text_sanitizer import (
     sanitize_for_tts_strict,
@@ -18,6 +19,7 @@ def _limit_and_chunk(text: str, max_length: int = 500) -> List[str]:
         Liste von Text-Chunks (80-180 Zeichen pro Chunk)
     """
     text = pre_sanitize_text(text)
+    text = unicodedata.normalize("NFC", text)
     # Text begrenzen auf max_length
     text = text.strip()
     if len(text) > max_length:

--- a/ws_server/tts/text_sanitizer.py
+++ b/ws_server/tts/text_sanitizer.py
@@ -44,8 +44,9 @@ def sanitize_for_tts_strict(text: str) -> str:
     t = t.translate(_FALLBACK_TRANSLATION)
     cleaned: list[str] = []
     for ch in t:
-        if ord(ch) > 127 and ch not in _ALLOWED:
-            logger.warning("Entferne unbekanntes Zeichen %r (U+%04X)", ch, ord(ch))
+        if ch not in _ALLOWED:
+            if not ch.isspace():
+                logger.warning("Entferne unbekanntes Zeichen %r (U+%04X)", ch, ord(ch))
             continue
         cleaned.append(ch)
     t = "".join(cleaned)
@@ -86,10 +87,14 @@ def pre_sanitize_text(text: str) -> str:
     return cleaned
 
 def analyze_problematic_chars(text: str) -> Dict[str, any]:
-    """Return a summary of non-ASCII or combining characters."""
+    """Return a summary of characters outside the allowed set."""
     if not text:
         return {}
-    unknown = [ch for ch in text if (ord(ch) > 127 and ch not in "äöüÄÖÜß") or unicodedata.category(ch) == "Mn"]
+    unknown = [
+        ch
+        for ch in text
+        if ch not in _ALLOWED and unicodedata.category(ch)[0] != "C"
+    ]
     return {"unique": sorted(set(unknown)), "count": len(unknown)}
 
 


### PR DESCRIPTION
## Summary
- filtere nicht erlaubte ASCII-Zeichen und Combining Marks vor der Phonemisierung
- normalisiere Chunking-Eingaben auf NFC
- erweitere Phonem-Audit und Tests um problematische Zeichen
- dokumentiere Sanitizer-Verhalten und ASCII-Filter

## Testing
- `pytest tests/test_sanitizer_phonemes.py -q --override-ini addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68a999107d8c8324b7fa66d6be1adf32