### PR TITLE
Add tests for metrics API and VAD behavior

### DIFF
--- a/tests/unit/test_metrics_http_api.py
+++ b/tests/unit/test_metrics_http_api.py
@@ -1,0 +1,34 @@
+import pytest
+from aiohttp import ClientSession, web
+from aiohttp.test_utils import TestClient, TestServer
+from prometheus_client import CONTENT_TYPE_LATEST
+
+from ws_server.metrics.http_api import create_app, start_http_server
+from ws_server.core.config import config
+
+
+@pytest.mark.asyncio
+async def test_create_app_routes():
+    app = create_app()
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/health")
+        assert resp.status == 200
+        assert await resp.json() == {"status": "green"}
+
+        resp = await client.get("/metrics")
+        assert resp.status == 200
+        assert resp.headers["Content-Type"] == CONTENT_TYPE_LATEST
+        text = await resp.text()
+        assert text.startswith("# HELP")
+
+
+@pytest.mark.asyncio
+async def test_start_http_server(unused_tcp_port):
+    runner = await start_http_server(unused_tcp_port)
+    try:
+        async with ClientSession() as session:
+            async with session.get(f"http://{config.ws_host}:{unused_tcp_port}/health") as resp:
+                assert resp.status == 200
+                assert await resp.json() == {"status": "green"}
+    finally:
+        await runner.cleanup()

--- a/tests/unit/test_vad_behavior.py
+++ b/tests/unit/test_vad_behavior.py
@@ -1,0 +1,31 @@
+import numpy as np
+from ws_server.audio.vad import VADConfig, VoiceActivityDetector, create_vad_processor
+
+
+def _create_speech_frame(vad: VoiceActivityDetector) -> np.ndarray:
+    return np.random.normal(0, 0.1, vad.frame_size).astype(np.float32)
+
+
+def _create_silence_frame(vad: VoiceActivityDetector) -> np.ndarray:
+    return np.zeros(vad.frame_size, dtype=np.float32)
+
+
+def test_vad_triggers_after_silence():
+    cfg = VADConfig(silence_duration_ms=60, min_speech_duration_ms=30)
+    vad = VoiceActivityDetector(cfg)
+    speech = _create_speech_frame(vad)
+    for _ in range(vad.min_speech_frames):
+        assert vad.process_frame(speech)
+    silence = _create_silence_frame(vad)
+    keep = True
+    for _ in range(vad.silence_frames_threshold):
+        keep = vad.process_frame(silence)
+    assert keep is False
+    stats = vad.get_stats()
+    assert stats["is_speech_started"] is True
+    assert stats["silence_frames"] >= vad.silence_frames_threshold
+
+
+def test_vad_process_error_returns_true():
+    vad = create_vad_processor()
+    assert vad.process_frame(None) is True


### PR DESCRIPTION
## Summary
- test ws_server.metrics.http_api for health and metrics endpoints
- cover VoiceActivityDetector silence detection and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99a66363c83249e1101c6354a141a