### PR TITLE
Add project metadata and fix Cordova plugin versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[project]
+name = "Sprachassistent"
+version = "0.1.0"
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/voice-assistant-apps/mobile/config.xml
+++ b/voice-assistant-apps/mobile/config.xml
@@ -126,7 +126,7 @@
     <plugin name="cordova-plugin-media" spec="^7.0.0" />
     <plugin name="cordova-plugin-file" spec="^8.0.0" />
     <plugin name="cordova-plugin-android-permissions" spec="^1.1.5" />
-    <plugin name="cordova-plugin-websocket" spec="^0.13.0" />
+    <plugin name="cordova-plugin-websocket" spec="^0.12.2" />
     <plugin name="cordova-plugin-app-version" spec="^0.1.14" />
     <plugin name="cordova-plugin-dialogs" spec="^2.0.2" />
     <plugin name="cordova-plugin-inappbrowser" spec="^6.0.0" />
@@ -134,7 +134,7 @@
     <!-- Erweiterte Plugins für erweiterte Funktionalität -->
     <plugin name="cordova-plugin-background-mode" spec="^0.7.3" />
     <plugin name="cordova-plugin-local-notification" spec="^0.9.0-beta.2" />
-    <plugin name="cordova-plugin-speech-recognition" spec="^1.2.0" />
+    <plugin name="cordova-plugin-speech-recognition" spec="^1.0.1" />
     <plugin name="cordova-plugin-tts" spec="^0.2.3" />
     
     <!-- Custom Hooks -->

--- a/voice-assistant-apps/mobile/package.json
+++ b/voice-assistant-apps/mobile/package.json
@@ -25,7 +25,7 @@
     "dev": "cordova run android --livereload",
     "prebuild": "npm run lint",
     "postbuild": "echo 'Build completed successfully!'",
-    "install-plugins": "cordova plugin add cordova-plugin-whitelist cordova-plugin-statusbar cordova-plugin-device cordova-plugin-splashscreen cordova-plugin-network-information cordova-plugin-vibration cordova-plugin-media-capture cordova-plugin-media cordova-plugin-file cordova-plugin-android-permissions cordova-plugin-websocket cordova-plugin-app-version cordova-plugin-dialogs cordova-plugin-inappbrowser cordova-plugin-background-mode cordova-plugin-local-notification cordova-plugin-speech-recognition cordova-plugin-tts"
+    "install-plugins": "cordova plugin add cordova-plugin-whitelist cordova-plugin-statusbar cordova-plugin-device cordova-plugin-splashscreen cordova-plugin-network-information cordova-plugin-vibration cordova-plugin-media-capture cordova-plugin-media cordova-plugin-file@8.0.0 cordova-plugin-android-permissions cordova-plugin-websocket@0.12.2 cordova-plugin-app-version cordova-plugin-dialogs cordova-plugin-inappbrowser cordova-plugin-background-mode cordova-plugin-local-notification cordova-plugin-speech-recognition@1.0.1 cordova-plugin-tts"
   },
   "keywords": [
     "voice",


### PR DESCRIPTION
## Summary
- define project name and version in `pyproject.toml`
- pin Cordova plugin versions for websocket, speech-recognition and file

## Testing
- `pytest` *(fails: tests/unit/test_metrics_http_api.py, tests/unit/test_performance_monitor.py, tests/unit/test_vad_behavior.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a0f03e688324b638358cb8beff70