### PR TITLE
Fix skills loader indentation and add regression test

### DIFF
--- a/tests/unit/test_skill_loading.py
+++ b/tests/unit/test_skill_loading.py
@@ -1,0 +1,8 @@
+import ws_server.routing.skills as skills_mod
+from ws_server.routing.skills import BaseSkill
+
+
+def test_load_all_skills_returns_instances():
+    skills = skills_mod.load_all_skills()
+    assert skills, "Es sollten Skills geladen werden"
+    assert all(isinstance(skill, BaseSkill) for skill in skills)

--- a/ws_server/routing/skills.py
+++ b/ws_server/routing/skills.py
@@ -5,20 +5,21 @@ from pathlib import Path
 from typing import List, Optional
 
 import pkgutil
+ 
 
-    class BaseSkill:
-        """Basis-Interface für alle Skills."""
-        intent_name: str = "base"
+class BaseSkill:
+    """Basis-Interface für alle Skills."""
+    intent_name: str = "base"
 
-        def can_handle(self, text: str) -> bool:
-            # TODO: implement intent matching logic in subclasses
-            #       (see TODO-Index.md: WS-Server / Protokolle)
-            raise NotImplementedError
+    def can_handle(self, text: str) -> bool:
+        # TODO: implement intent matching logic in subclasses
+        #       (see TODO-Index.md: WS-Server / Protokolle)
+        raise NotImplementedError
 
-        def handle(self, text: str) -> str:
-            # TODO: implement handler that returns skill response
-            #       (see TODO-Index.md: WS-Server / Protokolle)
-            raise NotImplementedError
+    def handle(self, text: str) -> str:
+        # TODO: implement handler that returns skill response
+        #       (see TODO-Index.md: WS-Server / Protokolle)
+        raise NotImplementedError
 
 def _discover_modules(path: Path) -> List[str]:
     return [name for _, name, _ in pkgutil.iter_modules([str(path)])]


### PR DESCRIPTION
## Summary
- fix unintended indentation in `BaseSkill` definition
- add unit test ensuring all skills load successfully

## Testing
- `PYTHONPATH=. pytest tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68a9ab298674832483114c1fe5d4c98b