### PR TITLE
Skip unavailable engines from STAGED_TTS env overrides

### DIFF
--- a/tests/unit/test_staged_tts_env_override.py
+++ b/tests/unit/test_staged_tts_env_override.py
@@ -1,0 +1,33 @@
+import asyncio
+from ws_server.tts.staged_tts.staged_processor import StagedTTSProcessor, StagedTTSConfig
+
+
+class OnlyZonosManager:
+    engines = {"zonos": object()}
+
+    async def synthesize(self, text, engine=None, voice=None):
+        if engine != "zonos":
+            raise ValueError("engine not available")
+
+        class R:
+            success = True
+            audio_data = b"x"
+            engine_used = engine
+            error_message = None
+            sample_rate = 22050
+            audio_format = "wav"
+
+        await asyncio.sleep(0)
+        return R()
+
+    def engine_allowed_for_voice(self, engine, voice):
+        return True
+
+
+def test_env_intro_override_skips_unavailable_engine(monkeypatch):
+    monkeypatch.setenv("STAGED_TTS_INTRO_ENGINE", "piper")
+    proc = StagedTTSProcessor(OnlyZonosManager(), StagedTTSConfig())
+    text = "Hallo Welt. " * 20
+    chunks = asyncio.run(proc.process_staged_tts(text, "de-thorsten-low"))
+    assert len(chunks) >= 1
+    assert all(c.engine == "zonos" for c in chunks)

--- a/ws_server/tts/staged_tts/staged_processor.py
+++ b/ws_server/tts/staged_tts/staged_processor.py
@@ -233,6 +233,13 @@ class StagedTTSProcessor:
         if intro in ("none", ""): intro = None
         if main in ("none", ""): main = None
 
+        if intro and not self._engine_available_for_voice(intro, canonical_voice):
+            logger.warning("Intro engine '%s' not available for voice '%s'", intro, canonical_voice)
+            intro = None
+        if main and not self._engine_available_for_voice(main, canonical_voice):
+            logger.warning("Main engine '%s' not available for voice '%s'", main, canonical_voice)
+            main = None
+
         plan = StagedPlan(intro_engine=intro or "auto", main_engine=main or "auto", fast_start=True)
 
         def pick_intro() -> Optional[str]:


### PR DESCRIPTION
## Summary
- ignore TTS engines from environment overrides when they failed to initialize
- add test ensuring intro override falls back when engine missing

## Testing
- `pytest tests/unit/test_staged_tts_env_override.py tests/unit/test_metrics_collector.py tests/unit/test_metrics_http_api.py tests/unit/test_metrics_perf_monitor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9ad02ef6c83248c89994479cdc032