### PR TITLE
docs: add centralized TODO references

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -2,6 +2,8 @@
 
 ## Backend
 - **backend/tts/piper_tts_engine.py**: remove deprecated wrapper for Piper engine. _Prio: Niedrig_
+- **ws_server/tts/engines/piper.py**: keep implementation in sync with backend wrapper. _Prio: Niedrig_
+- **torch.py / torchaudio.py / soundfile.py**: replace stub modules with real dependencies or dedicated mocks. _Prio: Niedrig_
 
 ## Frontend
 - **voice-assistant-apps/shared/core/VoiceAssistantCore.js**: consolidate with AudioStreamer to avoid duplicate streaming logic. _Prio: Mittel_
@@ -13,14 +15,19 @@
 - **ws_server/routing/skills.py**: flesh out skill interface and routing logic. _Prio: Hoch_
 - **ws_server/transport/fastapi_adapter.py**: implement FastAPI transport adapter. _Prio: Niedrig_
 - **ws_server/tts/text_sanitizer.py**: unify sanitizer, normalizer and chunking pipeline. _Prio: Niedrig_
+- **ws_server/tts/staged_tts/chunking.py**: review overlap with sanitizer/normalizer for unified pipeline. _Prio: Mittel_
+- **ws_server/tts/text_normalize.py**: clarify responsibilities with other sanitizer components. _Prio: Niedrig_
 
 ## Config
 - **ws_server/tts/voice_aliases.py**: unify voice alias config with `config/tts.json` and environment. _Prio: Niedrig_
 - **config/tts.json**: align with `voice_aliases.py` to remove duplication. _Prio: Niedrig_
+- **env.example**: consolidate TTS defaults with `config/tts.json` to prevent drift. _Prio: Niedrig_
 
 ## Dokumentation
 - **docs/Refaktorierungsplan.md**: add TODO stubs for true streaming. _Prio: Niedrig_
+- **docs/GUI-TODO.md**: review and merge GUI tasks into central roadmap. _Prio: Niedrig_
 
 ## ❓ Offene Fragen
 - ❓ Are VoiceAssistantCore and AudioStreamer both needed or can they be merged?
 - ❓ Is the legacy WS server still required, or can the compat layer be dropped?
+- ❓ Are the torch/torchaudio/soundfile stubs still necessary once real libraries are installed?

--- a/config/tts.json
+++ b/config/tts.json
@@ -1,4 +1,6 @@
 {
+  // TODO: align with ws_server/tts/voice_aliases.py to avoid duplicated voice settings
+  //       (see TODO-Index.md: Config)
   "default_engine": "piper",
   "engines": ["piper", "zonos"],
   "voice_map": {

--- a/env.example
+++ b/env.example
@@ -14,6 +14,8 @@ STT_DEVICE=cpu
 STT_PRECISION=int8
 
 # === TTS Configuration ===
+# TODO: consolidate with config/tts.json to prevent drifting defaults
+#       (see TODO-Index.md: Config)
 PIPER_MODEL=de-thorsten-low.onnx
 PIPER_MODEL_DIR=./models/piper
 KOKORO_MODEL=kokoro-v1.0.int8.onnx

--- a/soundfile.py
+++ b/soundfile.py
@@ -1,2 +1,5 @@
 def write(buf, data, sr, format='WAV', subtype='PCM_16'):
     buf.write(b'')
+
+# TODO: remove this soundfile stub once the real library is installed
+#       (see TODO-Index.md: Backend)

--- a/torch.py
+++ b/torch.py
@@ -4,6 +4,9 @@ import numpy as np
 float16 = 'float16'
 float32 = 'float32'
 
+# TODO: replace this minimal torch stub with the actual library or a proper
+#       test double (see TODO-Index.md: Backend)
+
 class _Cuda:
     @staticmethod
     def is_available() -> bool:

--- a/torchaudio.py
+++ b/torchaudio.py
@@ -9,3 +9,6 @@ class functional:
     @staticmethod
     def resample(wav, src_sr, dst_sr):
         return wav
+
+# TODO: replace this torchaudio stub with the real dependency when available
+#       (see TODO-Index.md: Backend)

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -19,6 +19,9 @@ Features integrated from previous versions:
 * Intent routing with optional Flowise/n8n calls (``aiohttp``)
 * Metrics API und TTS-Engine-Switching
 
+# TODO: clarify whether this legacy compat layer is still needed
+#       (see TODO-Index.md: ❓ Offene Fragen)
+
 # Hinweis: Der TTS-Wechsel wird vom ``TTSManager`` verwaltet und
 # die Authentifizierung erfolgt über ``auth.token_utils``. Weitere
 # Aufteilung in Module ist geplant.

--- a/ws_server/tts/engines/piper.py
+++ b/ws_server/tts/engines/piper.py
@@ -6,6 +6,9 @@ representation.  The engine reads the sample rate from the accompanying
 model JSON file and always returns proper WAV bytes.
 """
 
+# TODO: keep in sync with backend/tts/piper_tts_engine.py to avoid drift
+#       (see TODO-Index.md: Backend)
+
 from __future__ import annotations
 
 import asyncio

--- a/ws_server/tts/staged_tts/chunking.py
+++ b/ws_server/tts/staged_tts/chunking.py
@@ -7,6 +7,8 @@ from ws_server.tts.text_sanitizer import (
     sanitize_for_tts_strict,
     pre_sanitize_text,
 )
+# TODO: review overlap with text_sanitizer and text_normalize modules for a
+#       unified pipeline (see TODO-Index.md: WS-Server / Protokolle)
 def _limit_and_chunk(text: str, max_length: int = 500) -> List[str]:
     """
     Begrenze und segmentiere Text für staged TTS.

--- a/ws_server/tts/text_normalize.py
+++ b/ws_server/tts/text_normalize.py
@@ -5,6 +5,9 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# TODO: unify responsibilities with text_sanitizer and chunking for a single
+#       coherent pipeline (see TODO-Index.md: WS-Server / Protokolle)
+
 ZERO_WIDTH = dict.fromkeys(map(ord, "\u200B\u200C\u200D\u200E\u200F\u2060\uFEFF"), None)
 TYPO_MAP = {
     '‘': "'", '’': "'", '‚': ',', '‛': "'",


### PR DESCRIPTION
## Summary
- tag duplicated modules and stubs with TODO comments pointing to a central index
- track config and TTS pipeline cleanup tasks in `TODO-Index.md`
- document legacy server and dependency stubs for future removal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9b6d8aaf48324a6e1a6bfdc15633b