### PR TITLE
TODO-Hinweise für Zonos-Engine ergänzt

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -5,6 +5,7 @@
 - **ws_server/tts/engines/piper.py**: keep implementation in sync with backend wrapper. _Prio: Niedrig_
 - **torch.py / torchaudio.py / soundfile.py**: replace stub modules with real dependencies or dedicated mocks. _Prio: Niedrig_
 - **piper/__init__.py**: replace stub with real piper dependency. _Prio: Niedrig_
+- **backend/tts/engine_zonos.py**: replace silent exception passes with explicit error handling for sanitizer import and speed conditioning. _Prio: Niedrig_
 
 ## Frontend
 - **voice-assistant-apps/shared/core/VoiceAssistantCore.js**: consolidate with AudioStreamer to avoid duplicate streaming logic. _Prio: Mittel_

--- a/backend/tts/engine_zonos.py
+++ b/backend/tts/engine_zonos.py
@@ -139,6 +139,8 @@ class ZonosTTSEngine(BaseTTSEngine):
                 from ws_server.tts.text_normalize import sanitize_for_tts
                 text = sanitize_for_tts(text)
             except Exception:
+                # TODO: handle sanitize_for_tts import failure explicitly
+                #       instead of silent pass (see TODO-Index.md: Backend)
                 pass
 
             voice = voice_id or self._active_voice
@@ -167,6 +169,8 @@ class ZonosTTSEngine(BaseTTSEngine):
                 try:
                     conditioning["rate"] = float(speed)
                 except Exception:
+                    # TODO: handle invalid speed value gracefully instead of
+                    #       silent pass (see TODO-Index.md: Backend)
                     pass
 
             use_fp16 = (self.device == 'cuda')


### PR DESCRIPTION
## Zusammenfassung
- Stille Fehlerbehandlung in der Zonos-TTS-Engine durch TODO-Kommentare markiert
- TODO-Index um Hinweis zur Zonos-Engine erweitert

## Testanweisungen
- `./run_tests.sh` (schlägt derzeit fehl: ModuleNotFoundError: No module named 'ws_server')


------
https://chatgpt.com/codex/tasks/task_e_68a9bc68fb908324b56419358c0d84db