### PR TITLE
Add todo references for legacy skill and startup script

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -24,6 +24,7 @@
 - **ws_server/metrics/collector.py**: track memory usage and network throughput metrics. _Prio: Mittel_
 - **ws_server/tts/staged_tts/staged_processor.py**: make crossfade duration configurable. _Prio: Niedrig_
 - **ws_server/compat/legacy_ws_server.py.backup.int_fix**: remove outdated backup file or merge changes into main compat module. _Prio: Niedrig_
+- **archive/legacy_ws_server/skills/__init__.py**: implement BaseSkill methods or remove legacy skill module. _Prio: Niedrig_
 
 ## Config
 - **ws_server/tts/voice_aliases.py**: unify voice alias config with `config/tts.json` and environment. _Prio: Niedrig_
@@ -34,9 +35,13 @@
 - **docs/Refaktorierungsplan.md**: add TODO stubs for true streaming. _Prio: Niedrig_
 - **docs/GUI-TODO.md**: review and merge GUI tasks into central roadmap. _Prio: Niedrig_
 
+## Tools & Scripts
+- **start_voice_assistant.py**: replace silent `pass` blocks with explicit error handling. _Prio: Niedrig_
+
 ## ❓ Offene Fragen
 - ❓ Are VoiceAssistantCore and AudioStreamer both needed or can they be merged?
 - ❓ Is the legacy WS server still required, or can the compat layer be dropped?
 - ❓ Are the torch/torchaudio/soundfile stubs still necessary once real libraries are installed?
 - ❓ Is `gui/enhanced-voice-assistant.js` still required or can its features be merged into the shared core modules?
 - ❓ Can `ws_server/compat/legacy_ws_server.py.backup.int_fix` be removed after verifying no changes are needed?
+- ❓ Is the archived legacy skill system (`archive/legacy_ws_server`) still required or can it be removed entirely?

--- a/archive/legacy_ws_server/skills/__init__.py
+++ b/archive/legacy_ws_server/skills/__init__.py
@@ -9,10 +9,10 @@ class BaseSkill:
     intent_name: str = "base"
 
     def can_handle(self, text: str) -> bool:
-        raise NotImplementedError
+        raise NotImplementedError  # TODO: implement skill detection or remove legacy module (see TODO-Index.md: WS-Server / Protokolle)
 
     def handle(self, text: str) -> str:
-        raise NotImplementedError
+        raise NotImplementedError  # TODO: implement skill response handler or remove legacy module (see TODO-Index.md: WS-Server / Protokolle)
 
 def _discover_modules(path: Path) -> List[str]:
     return [name for _, name, _ in pkgutil.iter_modules([str(path)])]

--- a/start_voice_assistant.py
+++ b/start_voice_assistant.py
@@ -59,8 +59,8 @@ def kill_processes_on_ports(ports):
                                     time.sleep(0.5)
                                     try:
                                         os.kill(int(pid), signal.SIGKILL)
-                                    except:
-                                        pass
+                                    except Exception:
+                                        pass  # TODO: handle kill failure explicitly (see TODO-Index.md: Tools & Scripts)
                             except Exception as pe:
                                 print(f"   PID extraction failed: {pe}")
         except Exception as e:
@@ -86,8 +86,8 @@ def kill_processes_on_ports(ports):
                                     os.kill(int(pid), signal.SIGTERM)
                                     time.sleep(0.2)
                                     os.kill(int(pid), signal.SIGKILL)
-                                except:
-                                    pass
+                                except Exception:
+                                    pass  # TODO: handle kill failure explicitly (see TODO-Index.md: Tools & Scripts)
         except Exception as e:
             print(f"   lsof method failed: {e}")
 
@@ -176,7 +176,7 @@ def start_voice_assistant():
                     if line:
                         line_clean = line.strip()
                         print(f"   📋 {line_clean}")
-                        
+
                         # Check for success indicators
                         if "Voice server initialized successfully" in line:
                             websocket_ready = True
@@ -185,7 +185,7 @@ def start_voice_assistant():
                         elif "STT model" in line and "loaded" in line:
                             print("   ✅ STT Model ready!")
             except Exception:
-                pass
+                pass  # TODO: log subprocess read errors (see TODO-Index.md: Tools & Scripts)
             
             # Test endpoints every 5 seconds after 15s
             if i > 15 and i % 5 == 0:


### PR DESCRIPTION
## Summary
- document unimplemented legacy skill methods with TODO references
- annotate server start script with TODOs for unhandled errors
- extend TODO index with new script and legacy skill entries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9be4b6d5883248ed584b4bbff88ad