### PR TITLE
docs: expand TODO index and annotate TTS error handling

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -2,7 +2,7 @@
 
 ## Backend
 - **backend/tts/piper_tts_engine.py**: remove deprecated wrapper for Piper engine. _Prio: Niedrig_
-- **ws_server/tts/engines/piper.py**: keep implementation in sync with backend wrapper. _Prio: Niedrig_
+- **ws_server/tts/engines/piper.py**: keep implementation in sync with backend wrapper; handle sample rate read errors explicitly. _Prio: Niedrig_
 - **torch.py / torchaudio.py / soundfile.py**: replace stub modules with real dependencies or dedicated mocks. _Prio: Niedrig_
 - **piper/__init__.py**: replace stub with real piper dependency. _Prio: Niedrig_
 - **backend/tts/engine_zonos.py**: replace silent exception passes with explicit error handling for sanitizer import and speed conditioning. _Prio: Niedrig_
@@ -14,7 +14,7 @@
 
 ## WS-Server / Protokolle
 - **ws_server/stt/in_memory.py**: implement streaming support without buffering entire audio. _Prio: Hoch_
-- **ws_server/compat/legacy_ws_server.py**: stream chunk-wise without buffering entire audio. _Prio: Mittel_
+- **ws_server/compat/legacy_ws_server.py**: stream chunk-wise without buffering entire audio; log Kokoro voice detection errors instead of silent pass. _Prio: Mittel_
 - **ws_server/routing/skills.py**: flesh out skill interface and routing logic. _Prio: Hoch_
 - **ws_server/transport/fastapi_adapter.py**: implement FastAPI transport adapter. _Prio: Niedrig_
 - **ws_server/tts/text_sanitizer.py**: unify sanitizer, normalizer and chunking pipeline. _Prio: Niedrig_

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -123,6 +123,8 @@ def _kokoro_voice_labels(voices_path: str, model_path: str):
             label = f"{pretty} [{k}]"
             out.append({"label": label, "key": k})
     except Exception:
+        # TODO: log Kokoro voice detection errors instead of silent pass
+        #       (see TODO-Index.md: WS-Server / Protokolle)
         pass
     return out
 

--- a/ws_server/tts/engines/piper.py
+++ b/ws_server/tts/engines/piper.py
@@ -132,6 +132,8 @@ class PiperTTSEngine(BaseTTSEngine):
             if sr > 0:
                 return sr
         except Exception:
+            # TODO: handle sample rate JSON read errors explicitly instead of
+            #       silent pass (see TODO-Index.md: Backend)
             pass
         if "de_DE-thorsten-low" in model_path:
             logger.warning("piper: sample_rate missing – fallback 22050 Hz")


### PR DESCRIPTION
## Summary
- note piper's silent sample rate failures in TODO index and source
- document Kokoro voice detection errors and cross-link to TODO index

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9bfd880f883249888d1fbb0b70f28