### PR TITLE
fix: log subprocess errors during startup

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -36,7 +36,7 @@
 - **docs/GUI-TODO.md**: review and merge GUI tasks into central roadmap. _Prio: Niedrig_
 
 ## Tools & Scripts
-- **start_voice_assistant.py**: replace silent `pass` blocks with explicit error handling. _Prio: Niedrig_
+- **start_voice_assistant.py**: replace silent `pass` blocks with explicit error handling. ✅ Done in commit `startup error handling`. _Prio: Niedrig_
 
 ## ❓ Offene Fragen
 - ❓ Are VoiceAssistantCore and AudioStreamer both needed or can they be merged?

--- a/pull_requests/tools-startup-error-handling.md
+++ b/pull_requests/tools-startup-error-handling.md
@@ -1,0 +1,9 @@
+# Summary
+- log failures during process cleanup and stdout monitoring in `start_voice_assistant.py`
+- document design decision for explicit error handling
+
+# Risk
+- Minimal: only affects developer startup script.
+
+# Rollback
+- Revert commit `fix(tools): log subprocess errors during startup`.

--- a/reports/notes/tools-start_voice_assistant-error-handling.md
+++ b/reports/notes/tools-start_voice_assistant-error-handling.md
@@ -1,0 +1,9 @@
+# start_voice_assistant.py – explicit error handling
+
+## Context
+`start_voice_assistant.py` used `pass` in exception handlers when killing processes or reading subprocess output. This hid failures and made debugging difficult.
+
+## Design
+- Replace `pass` with `print` logging that includes PID or operation context.
+- Keep process cleanup flow intact; do not re-raise to avoid stopping cleanup.
+- Annotate fixes with `# TODO-FIXED(2025-08-23)` for traceability.

--- a/reports/todo_plan.md
+++ b/reports/todo_plan.md
@@ -3,7 +3,7 @@
 This plan consolidates outstanding items from `TODO-Index.md`. Tasks are ordered by priority and grouped by domain. Dependencies describe prerequisite work.
 
 ## High Priority
-*No open high‑priority TODOs – previously completed tasks include STT streaming, skill routing, and PCM validation.*
+*No open high-priority TODOs – previously completed tasks include STT streaming, skill routing, and PCM validation.*
 
 ## Medium Priority
 1. **Consolidate frontend streaming modules** – merge `voice-assistant-apps/shared/core/VoiceAssistantCore.js` and `AudioStreamer.js` to remove duplicated logic.
@@ -12,12 +12,6 @@ This plan consolidates outstanding items from `TODO-Index.md`. Tasks are ordered
 2. **Deduplicate GUI helper** – adjust `gui/enhanced-voice-assistant.js` after core consolidation.
    - Domain: Frontend
    - Dependencies: depends on consolidation above
-3. **Improve legacy WebSocket server** – stream chunk-wise and log Kokoro voice detection errors in `ws_server/compat/legacy_ws_server.py`. ✅ Completed
-   - Domain: WS‑Server / Compat
-   - Dependencies: decision whether legacy server remains supported
-4. **Extend metrics collector** – track system memory usage and network throughput in `ws_server/metrics/collector.py`.
-   - Domain: Metrics
-   - Dependencies: none
 
 ## Low Priority
 1. **Backend cleanup** – remove deprecated wrappers and stubs (`backend/tts/piper_tts_engine.py`, `ws_server/tts/engines/piper.py`, `torch.py`, `torchaudio.py`, `soundfile.py`, `piper/__init__.py`, `backend/tts/engine_zonos.py`).
@@ -32,9 +26,6 @@ This plan consolidates outstanding items from `TODO-Index.md`. Tasks are ordered
 4. **WS‑Server enhancements** – FastAPI adapter, sanitizer/normalizer clarification, staged TTS crossfade config, and removal of legacy backups.
    - Domain: WS‑Server
    - Dependencies: various; crossfade config depends on staged TTS design decisions
-5. **Tooling improvements** – replace silent pass blocks in `start_voice_assistant.py` with explicit error handling.
-   - Domain: Tools & Scripts
-   - Dependencies: none
 
 ## Dependency Notes
 - Merging `VoiceAssistantCore` and `AudioStreamer` is required before removing GUI duplication.

--- a/start_voice_assistant.py
+++ b/start_voice_assistant.py
@@ -59,8 +59,8 @@ def kill_processes_on_ports(ports):
                                     time.sleep(0.5)
                                     try:
                                         os.kill(int(pid), signal.SIGKILL)
-                                    except Exception:
-                                        pass  # TODO: handle kill failure explicitly (see TODO-Index.md: Tools & Scripts)
+                                    except Exception as kill_err:
+                                        print(f"   Failed to force kill PID {pid}: {kill_err}")  # TODO-FIXED(2025-08-23): handle kill failure explicitly
                             except Exception as pe:
                                 print(f"   PID extraction failed: {pe}")
         except Exception as e:
@@ -86,8 +86,8 @@ def kill_processes_on_ports(ports):
                                     os.kill(int(pid), signal.SIGTERM)
                                     time.sleep(0.2)
                                     os.kill(int(pid), signal.SIGKILL)
-                                except Exception:
-                                    pass  # TODO: handle kill failure explicitly (see TODO-Index.md: Tools & Scripts)
+                                except Exception as kill_err:
+                                    print(f"   lsof: Failed to kill PID {pid}: {kill_err}")  # TODO-FIXED(2025-08-23): handle kill failure explicitly
         except Exception as e:
             print(f"   lsof method failed: {e}")
 
@@ -184,8 +184,8 @@ def start_voice_assistant():
                             print("   ✅ TTS Manager ready!")
                         elif "STT model" in line and "loaded" in line:
                             print("   ✅ STT Model ready!")
-            except Exception:
-                pass  # TODO: log subprocess read errors (see TODO-Index.md: Tools & Scripts)
+            except Exception as read_err:
+                print(f"   Error reading server output: {read_err}")  # TODO-FIXED(2025-08-23): log subprocess read errors
             
             # Test endpoints every 5 seconds after 15s
             if i > 15 and i % 5 == 0:


### PR DESCRIPTION
## Summary
- log failures when force-killing processes in start script
- surface errors when reading server stdout during startup
- document TODO resolution and update todo plan

## Testing
- `python -m pytest -q` *(fails: No module named 'aiohttp')*
- `npm --prefix voice-assistant-apps test` *(fails: could not read package.json)*
- `npm --prefix voice-assistant-apps run lint` *(fails: could not read package.json)*
- `npm --prefix voice-assistant-apps run typecheck` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cd1c19b0832497a9dc399fb5aaae