### PR TITLE
feat(ws-server): configurable TTS crossfade

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -22,7 +22,7 @@
 - **ws_server/tts/text_normalize.py**: clarify responsibilities with other sanitizer components. _Prio: Niedrig_
 - **ws_server/protocol/binary_v2.py**: verify PCM format and sample rate before processing. ✅ Done in commit `binary PCM validation`. _Prio: Hoch_
 - **ws_server/metrics/collector.py**: track memory usage and network throughput metrics. ✅ Done in commit `metrics network throughput`. _Prio: Mittel_
-- **ws_server/tts/staged_tts/staged_processor.py**: make crossfade duration configurable. _Prio: Niedrig_
+- **ws_server/tts/staged_tts/staged_processor.py**: make crossfade duration configurable. ✅ Done in commit `staged tts crossfade env`. _Prio: Niedrig_
 - **ws_server/compat/legacy_ws_server.py.backup.int_fix**: remove outdated backup file or merge changes into main compat module. _Prio: Niedrig_
 - **archive/legacy_ws_server/skills/__init__.py**: implement BaseSkill methods or remove legacy skill module. _Prio: Niedrig_
 

--- a/pull_requests/ws-server-crossfade.md
+++ b/pull_requests/ws-server-crossfade.md
@@ -1,0 +1,9 @@
+## Summary
+- allow configuring staged TTS crossfade via `STAGED_TTS_CROSSFADE_MS`
+- document removal of crossfade TODO and update task plan
+
+## Risk
+- low: optional env var with sane default
+
+## Rollback
+- revert commit `feat(ws-server): configurable TTS crossfade`

--- a/reports/notes/staged_processor_crossfade.md
+++ b/reports/notes/staged_processor_crossfade.md
@@ -1,0 +1,7 @@
+**Goal:** Make crossfade duration configurable via environment variable for staged TTS.
+
+**Design:**
+- Extend `StagedTTSConfig` with `from_env` classmethod.
+- Allow overriding `crossfade_duration_ms` using `STAGED_TTS_CROSSFADE_MS`.
+- `StagedTTSProcessor` uses `StagedTTSConfig.from_env()` when no config supplied.
+- Ensure chunk messages include the configured crossfade value.

--- a/reports/todo_plan.md
+++ b/reports/todo_plan.md
@@ -23,9 +23,9 @@ This plan consolidates outstanding items from `TODO-Index.md`. Tasks are ordered
 3. **Documentation upkeep** – update `docs/Refaktorierungsplan.md` and `docs/GUI-TODO.md`.
    - Domain: Docs
    - Dependencies: none
-4. **WS‑Server enhancements** – FastAPI adapter, sanitizer/normalizer clarification, staged TTS crossfade config, and removal of legacy backups.
+4. **WS‑Server enhancements** – FastAPI adapter, sanitizer/normalizer clarification, and removal of legacy backups.
    - Domain: WS‑Server
-   - Dependencies: various; crossfade config depends on staged TTS design decisions
+   - Dependencies: various
 
 ## Dependency Notes
 - Merging `VoiceAssistantCore` and `AudioStreamer` is required before removing GUI duplication.

--- a/tests/unit/test_staged_tts_crossfade.py
+++ b/tests/unit/test_staged_tts_crossfade.py
@@ -1,0 +1,13 @@
+from ws_server.tts.staged_tts.staged_processor import StagedTTSProcessor, TTSChunk
+
+
+class DummyManager:
+    pass
+
+
+def test_crossfade_env_override(monkeypatch):
+    monkeypatch.setenv("STAGED_TTS_CROSSFADE_MS", "250")
+    proc = StagedTTSProcessor(DummyManager())
+    chunk = TTSChunk("x", 0, 1, "piper", "hi", b"x", True, 22050)
+    msg = proc.create_chunk_message(chunk)
+    assert msg["crossfade_ms"] == 250


### PR DESCRIPTION
## Summary
- allow configuring staged TTS crossfade via env variable
- document removal of crossfade TODO and update work plan

## Testing
- `pytest -q`
- `npm --prefix voice-assistant-apps/desktop test` *(fails: Missing script)*
- `npm --prefix voice-assistant-apps/desktop run lint` *(fails: Missing script)*
- `npm --prefix voice-assistant-apps/desktop run typecheck` *(fails: Missing script)*
- `npm --prefix voice-assistant-apps/mobile run lint`
- `npm --prefix voice-assistant-apps/mobile run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ce18eedc832494c600d4c5f63446