### PR TITLE
fix(tts): warn on sanitizer and speed issues

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -5,7 +5,7 @@
 - **ws_server/tts/engines/piper.py**: keep implementation in sync with backend wrapper; handle sample rate read errors explicitly. _Prio: Niedrig_
 - **torch.py / torchaudio.py / soundfile.py**: replace stub modules with real dependencies or dedicated mocks. _Prio: Niedrig_
 - **piper/__init__.py**: replace stub with real piper dependency. _Prio: Niedrig_
-- **backend/tts/engine_zonos.py**: replace silent exception passes with explicit error handling for sanitizer import and speed conditioning. _Prio: Niedrig_
+- **backend/tts/engine_zonos.py**: replace silent exception passes with explicit error handling for sanitizer import and speed conditioning. ✅ Done in commit `zonos error handling`. _Prio: Niedrig_
 
 ## Frontend
 - **voice-assistant-apps/shared/core/VoiceAssistantCore.js**: consolidate with AudioStreamer to avoid duplicate streaming logic. _Prio: Mittel_

--- a/backend/tts/engine_zonos.py
+++ b/backend/tts/engine_zonos.py
@@ -138,10 +138,9 @@ class ZonosTTSEngine(BaseTTSEngine):
             try:  # pragma: no cover - Import kann scheitern
                 from ws_server.tts.text_normalize import sanitize_for_tts
                 text = sanitize_for_tts(text)
-            except Exception:
-                # TODO: handle sanitize_for_tts import failure explicitly
-                #       instead of silent pass (see TODO-Index.md: Backend)
-                pass
+            except Exception as e:
+                # TODO-FIXED(2025-08-23): log missing sanitizer instead of silent pass
+                logger.warning("Zonos: Textsanitizer nicht verfügbar: %s", e)
 
             voice = voice_id or self._active_voice
             lang = _normalize_lang(language or self._active_lang or 'de')
@@ -168,10 +167,9 @@ class ZonosTTSEngine(BaseTTSEngine):
             if speed is not None:
                 try:
                     conditioning["rate"] = float(speed)
-                except Exception:
-                    # TODO: handle invalid speed value gracefully instead of
-                    #       silent pass (see TODO-Index.md: Backend)
-                    pass
+                except Exception as e:
+                    # TODO-FIXED(2025-08-23): warn on invalid speed instead of silent pass
+                    logger.warning("Zonos: Ungültiger Geschwindigkeitswert %s: %s", speed, e)
 
             use_fp16 = (self.device == 'cuda')
 

--- a/pull_requests/tts-zonos-error-handling.md
+++ b/pull_requests/tts-zonos-error-handling.md
@@ -1,0 +1,9 @@
+# Summary
+- log missing text sanitizer and invalid speed values in Zonos TTS engine
+- document plan and design notes for remaining TODOs
+
+# Risk
+- low: only adds warnings and does not alter synthesis flow
+
+# Rollback
+- revert commit `fix(tts): warn on sanitizer and speed issues`

--- a/reports/notes/backend_engine_zonos_error_handling.md
+++ b/reports/notes/backend_engine_zonos_error_handling.md
@@ -1,0 +1,9 @@
+# Zonos Engine Error Handling
+
+## Context
+`backend/tts/engine_zonos.py` silently ignores failures when importing the text sanitizer and when applying speed conditioning. This hides configuration errors and hampers debugging.
+
+## Proposal
+- Wrap the sanitizer import in `try/except` and log a warning if it fails.
+- Validate the `speed` parameter; on failure, log a warning including the invalid value.
+- Preserve synthesis flow by continuing with defaults after logging.

--- a/reports/todo_plan.md
+++ b/reports/todo_plan.md
@@ -1,53 +1,55 @@
 # TODO Work Plan
 
-This plan summarizes remaining TODOs from `TODO-Index.md`, ordered by priority and grouped by domain. High priority items are none; medium items first, then low.
+## Overview
+Prioritized plan derived from TODO-Index.md. High priorities already completed; remaining tasks are Medium or Low. Tasks grouped by domain with dependencies.
 
 ## Medium Priority
-1. **Merge streaming logic (Frontend)**  
+1. **Consolidate streaming logic**  
    - Files: `voice-assistant-apps/shared/core/VoiceAssistantCore.js`, `voice-assistant-apps/shared/core/AudioStreamer.js`, `gui/enhanced-voice-assistant.js`  
-   - Goal: consolidate duplicated audio streaming code.  
-   - Dependencies: clarify if both modules are still required (see open question).  
-   - Blockers: pending decision on whether to merge or keep separate modules.
+   - Domain: Frontend  
+   - Description: Merge duplicated audio streaming and WebSocket handling across these modules.  
+   - Dependencies: Requires agreement on single source of truth for streaming API. Blocked by open question whether both Core and AudioStreamer are needed.
 
 ## Low Priority
-1. **Remove legacy WS backup file**  
-   - File: `ws_server/compat/legacy_ws_server.py.backup.int_fix`  
-   - Goal: delete outdated backup file now that changes reside in `legacy_ws_server.py`.  
-   - Dependencies: none; verify no unique code remains.
-2. **Voice alias configuration unification**  
-   - Files: `ws_server/tts/voice_aliases.py`, `config/tts.json`, `env.example`  
-   - Goal: maintain a single source of truth for TTS voice aliases and defaults.  
-   - Dependencies: need agreement on canonical config location.
-3. **Cleanup stub modules**  
+2. **Remove deprecated Piper wrapper**  
+   - File: `backend/tts/piper_tts_engine.py`  
+   - Domain: Backend  
+   - Description: Delete legacy wrapper once piper engine migrated.
+
+3. **Sync WS Piper engine and handle sample‑rate errors**  
+   - File: `ws_server/tts/engines/piper.py`  
+   - Domain: Backend/WS  
+   - Description: Keep parity with backend wrapper; raise explicit errors when sample rate read fails.
+
+4. **Replace torch/torchaudio/soundfile stubs**  
    - Files: `torch.py`, `torchaudio.py`, `soundfile.py`, `piper/__init__.py`  
-   - Goal: replace temporary stubs with real dependencies or proper mocks.  
-   - Dependencies: availability of required packages in environment.
-4. **Backend TTS wrappers**  
-   - Files: `backend/tts/piper_tts_engine.py`, `ws_server/tts/engines/piper.py`, `backend/tts/engine_zonos.py`  
-   - Goal: remove deprecated wrappers and replace silent exception blocks with explicit error handling.  
-   - Dependencies: ensure new implementations cover previous behaviour.
-5. **Text sanitizer and normalizer refactor**  
-   - Files: `ws_server/tts/text_sanitizer.py`, `ws_server/tts/text_normalize.py`  
-   - Goal: unify responsibilities and integrate with existing chunking pipeline.  
-   - Dependencies: rely on outcome of chunking pipeline review already completed.
+   - Domain: Backend/Tools  
+   - Description: Use real dependencies or dedicated test mocks.
+
+5. **Explicit error handling in Zonos TTS engine**  
+   - File: `backend/tts/engine_zonos.py`  
+   - Domain: Backend  
+   - Description: Log sanitizer import failures and invalid speed conditioning instead of silent pass.
+
 6. **FastAPI transport adapter**  
    - File: `ws_server/transport/fastapi_adapter.py`  
-   - Goal: implement FastAPI adapter to expose WebSocket server via FastAPI.  
-   - Dependencies: none noted.
-7. **Legacy skill module cleanup**  
-   - File: `archive/legacy_ws_server/skills/__init__.py`  
-   - Goal: implement `BaseSkill` methods or remove the archived module.  
-   - Dependencies: decision on whether archived server remains required.
-8. **Documentation updates**  
+   - Domain: WS-Server  
+   - Description: Implement adapter to expose WebSocket server via FastAPI.
+
+7. **Unify text sanitizing pipeline**  
+   - Files: `ws_server/tts/text_sanitizer.py`, `ws_server/tts/text_normalize.py`, `ws_server/tts/staged_tts/chunking.py`  
+   - Domain: WS-Server  
+   - Description: Ensure sanitizer, normalizer and chunking share a single pipeline.
+
+8. **Config consistency for TTS voices**  
+   - Files: `ws_server/tts/voice_aliases.py`, `config/tts.json`, `env.example`  
+   - Domain: Config  
+   - Description: Derive voice aliases from config and environment to avoid duplication.
+
+9. **Documentation cleanup**  
    - Files: `docs/Refaktorierungsplan.md`, `docs/GUI-TODO.md`  
-   - Goal: add streaming TODOs and consolidate GUI tasks into central roadmap.  
-   - Dependencies: none.
+   - Domain: Docs  
+   - Description: Add streaming TODO stubs and merge GUI tasks into central roadmap.
 
-## Open Questions
-- Are `VoiceAssistantCore` and `AudioStreamer` both needed or can they be merged?
-- Is the legacy WS server still required, or can the compat layer be dropped?
-- Are the torch/torchaudio/soundfile stubs still necessary once real libraries are installed?
-- Is `gui/enhanced-voice-assistant.js` still required or can its features be merged into the shared core modules?
-- Can `ws_server/compat/legacy_ws_server.py.backup.int_fix` be removed after verifying no changes are needed?
-- Is the archived legacy skill system (`archive/legacy_ws_server`) still required or can it be removed entirely?
-
+## Notes
+- Open questions from TODO-Index remain regarding module consolidation, legacy server removal, and stub dependencies. These require further clarification before implementation.


### PR DESCRIPTION
## Summary
- log missing text sanitizer and invalid speed values in Zonos TTS engine
- document TODO work plan

## Testing
- `pytest -q`
- `npm run lint` *(fails: ENOENT package.json)*
- `npm test` *(fails: ENOENT package.json)*
- `npm run typecheck` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d1c74a5c83249f15f24856c7d419