### PR TITLE
docs: add true streaming TODO stubs to refactor plan

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -32,7 +32,7 @@
 - **env.example**: consolidate TTS defaults with `config/tts.json` to prevent drift. _Prio: Niedrig_
 
 ## Dokumentation
-- **docs/Refaktorierungsplan.md**: add TODO stubs for true streaming. _Prio: Niedrig_
+- **docs/Refaktorierungsplan.md**: add TODO stubs for true streaming. ✅ Done in commit `docs true streaming stubs`. _Prio: Niedrig_
 - **docs/GUI-TODO.md**: review and merge GUI tasks into central roadmap. _Prio: Niedrig_
 
 ## Tools & Scripts

--- a/docs/Refaktorierungsplan.md
+++ b/docs/Refaktorierungsplan.md
@@ -170,8 +170,12 @@ sprint-5(tts): unify engine sources, add lazy loading and robust fallback
 **Tasks**
 
 * Convert STT ingestion to in‑memory buffers (`bytes` → `np.int16`), remove WAV temp files and subprocesses.
-* Keep current behavior and quality; add TODO stubs for true streaming
-  (see TODO-Index.md: Dokumentation).
+* Keep current behavior and quality.
+* TODO (true streaming):
+  - incremental Whisper chunking
+  - forward partial transcripts to intent routing
+  - stream TTS answers without full buffering
+<!-- TODO-FIXED(2024-07-06): true streaming TODO stubs added -->
 
 **Acceptance**
 

--- a/pull_requests/docs-true-streaming.md
+++ b/pull_requests/docs-true-streaming.md
@@ -1,0 +1,9 @@
+# Summary
+- add explicit TODO list for true streaming in Sprint 6 of refactor plan
+- document design note for future streaming work
+
+# Risk
+- none; documentation only
+
+# Rollback
+- revert commit `docs(refactor-plan): add true streaming TODO stubs`

--- a/reports/notes/docs-true-streaming.md
+++ b/reports/notes/docs-true-streaming.md
@@ -1,0 +1,9 @@
+# docs/Refaktorierungsplan.md – add TODO stubs for true streaming
+
+## Context
+Sprint 6 mentions STT in-memory streaming but lacks explicit TODOs for future true streaming implementation.
+
+## Design
+- Add a clear TODO list under Sprint 6 outlining next steps toward real streaming STT.
+- Use HTML comment with TODO-FIXED tag to mark completion of this documentation update.
+- Keep existing structure; ensure wording stays concise and matches project tone.

--- a/reports/todo_plan.md
+++ b/reports/todo_plan.md
@@ -1,58 +1,26 @@
-# TODO Work Plan
+# TODO Plan
 
 ## Overview
-Prioritized plan derived from TODO-Index.md. High priorities already completed; remaining tasks are Medium or Low. Tasks grouped by domain with dependencies.
+A prioritized list of open TODOs extracted from `TODO-Index.md` with dependencies and scope.
+
+## High Priority
+*(none pending)*
 
 ## Medium Priority
-1. **Consolidate streaming logic**  
-   - Files: `voice-assistant-apps/shared/core/VoiceAssistantCore.js`, `voice-assistant-apps/shared/core/AudioStreamer.js`, `gui/enhanced-voice-assistant.js`  
-   - Domain: Frontend  
-   - Description: Merge duplicated audio streaming and WebSocket handling across these modules.  
-   - Dependencies: Requires agreement on single source of truth for streaming API. Blocked by open question whether both Core and AudioStreamer are needed.
+1. **Merge streaming logic** – consolidate `VoiceAssistantCore.js`, `AudioStreamer.js`, and `gui/enhanced-voice-assistant.js` to remove duplicate client streaming code. (Frontend)
+   - Depends on resolving whether VoiceAssistantCore and AudioStreamer can be fully merged.
 
 ## Low Priority
-2. **Remove deprecated Piper wrapper**  
-   - File: `backend/tts/piper_tts_engine.py`  
-   - Domain: Backend  
-   - Description: Delete legacy wrapper once piper engine migrated.
+1. **Real dependency modules** – replace stub modules `torch.py`, `torchaudio.py`, `soundfile.py`, and `piper/__init__.py` with real dependencies or test mocks. (Backend)
+2. **FastAPI transport adapter** – implement `ws_server/transport/fastapi_adapter.py` to expose the server via FastAPI. (WS-Server)
+3. **Unified text pipeline** – refine `ws_server/tts/text_sanitizer.py` and `text_normalize.py` into a coherent sanitizer/normalizer/chunking pipeline. (WS-Server)
+4. **Legacy skill cleanup** – decide on `archive/legacy_ws_server/skills/__init__.py`: implement missing `BaseSkill` methods or remove module. (WS-Server)
+5. **Voice configuration single source** – align `ws_server/tts/voice_aliases.py`, `config/tts.json`, and `.env` defaults. (Config)
+6. **TTS config consolidation** – ensure `env.example` reflects defaults from `config/tts.json` to prevent drift. (Config)
+7. **Documentation updates** – `docs/Refaktorierungsplan.md` needs TODO stubs for true streaming; `docs/GUI-TODO.md` tasks should be merged into the central roadmap. (Docs)
 
-3. **Sync WS Piper engine and handle sample‑rate errors**  
-   - File: `ws_server/tts/engines/piper.py`  
-   - Domain: Backend/WS  
-   - Description: Keep parity with backend wrapper; raise explicit errors when sample rate read fails.
+## Dependency Map
+- Voice configuration tasks (5 & 6) depend on the decision of a single canonical config source.
+- Unified text pipeline (3) should precede any further TTS feature work.
+- Legacy skill cleanup (4) can proceed independently after confirming no active references.
 
-4. **Replace torch/torchaudio/soundfile stubs**  
-   - Files: `torch.py`, `torchaudio.py`, `soundfile.py`, `piper/__init__.py`  
-   - Domain: Backend/Tools  
-   - Description: Use real dependencies or dedicated test mocks.
-
-5. **Explicit error handling in Zonos TTS engine**  
-   - File: `backend/tts/engine_zonos.py`  
-   - Domain: Backend  
-   - Description: Log sanitizer import failures and invalid speed conditioning instead of silent pass.
-
-6. **FastAPI transport adapter**  
-   - File: `ws_server/transport/fastapi_adapter.py`  
-   - Domain: WS-Server  
-   - Description: Implement adapter to expose WebSocket server via FastAPI.
-
-7. **Unify text sanitizing pipeline**  
-   - Files: `ws_server/tts/text_sanitizer.py`, `ws_server/tts/text_normalize.py`, `ws_server/tts/staged_tts/chunking.py`  
-   - Domain: WS-Server  
-   - Description: Ensure sanitizer, normalizer and chunking share a single pipeline.
-
-8. **Config consistency for TTS voices**  
-   - Files: `ws_server/tts/voice_aliases.py`, `config/tts.json`, `env.example`  
-   - Domain: Config  
-   - Description: Derive voice aliases from config and environment to avoid duplication.
-
-9. **Documentation cleanup**  
-   - Files: `docs/Refaktorierungsplan.md`, `docs/GUI-TODO.md`  
-   - Domain: Docs  
-   - Description: Add streaming TODO stubs and merge GUI tasks into central roadmap.
-
-## Notes
-- Open questions from TODO-Index remain regarding module consolidation, legacy server removal, and stub dependencies. These require further clarification before implementation.
-
-## This iteration
-- Completed tasks 2 and 3 (Piper wrapper removal and sample-rate error handling).


### PR DESCRIPTION
## Summary
- add explicit TODO list for true streaming under Sprint 6
- document design note for future streaming work
- update TODO index

## Testing
- `python -m pytest -q`
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Missing script)
- `npm run typecheck` (fails: Missing script)
- `ruff check .` (1422 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a9d5a69f908324b6c7e2ca253a8dd5