### PR TITLE
feat(ws_server): add FastAPI transport adapter

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -18,7 +18,7 @@
 - **ws_server/stt/in_memory.py**: implement streaming support without buffering entire audio. ✅ Done in commit `stt streaming`. _Prio: Hoch_
 - **ws_server/compat/legacy_ws_server.py**: stream chunk-wise without buffering entire audio; log Kokoro voice detection errors instead of silent pass. ✅ Done in commit `legacy ws streaming`. _Prio: Mittel_
 - **ws_server/routing/skills.py**: flesh out skill interface and routing logic. ✅ Done in commit `skill interface abc`. _Prio: Hoch_
-- **ws_server/transport/fastapi_adapter.py**: implement FastAPI transport adapter. _Prio: Niedrig_
+- **ws_server/transport/fastapi_adapter.py**: implement FastAPI transport adapter. ✅ Done in commit `fastapi adapter`. _Prio: Niedrig_
 - **ws_server/tts/text_sanitizer.py**: unify sanitizer, normalizer and chunking pipeline. ✅ Done in commit `unify text pipeline`. _Prio: Niedrig_
 - **ws_server/tts/staged_tts/chunking.py**: review overlap with sanitizer/normalizer for unified pipeline. ✅ Done in commit `chunking pipeline unify`.
 - **ws_server/tts/text_normalize.py**: clarify responsibilities with other sanitizer components. ✅ Done in commit `unify text pipeline`. _Prio: Niedrig_

--- a/pull_requests/ws_server-fastapi-adapter.md
+++ b/pull_requests/ws_server-fastapi-adapter.md
@@ -1,0 +1,9 @@
+# Summary
+- implement FastAPI transport adapter with token check and optional voice server
+- add unit tests for token handling
+
+# Risk
+- minimal: adapter is isolated and not yet used in production
+
+# Rollback
+- revert commit `feat(ws_server): add fastapi transport adapter`

--- a/reports/notes/ws_server_transport_fastapi_adapter.md
+++ b/reports/notes/ws_server_transport_fastapi_adapter.md
@@ -1,0 +1,9 @@
+# ws_server/transport/fastapi_adapter.py
+
+## Design Notes
+- Provide FastAPI application so HTTP clients can reuse WebSocket server logic.
+- Expose `create_app()` factory accepting optional `VoiceServer` for testability.
+- Implement minimal `WebSocketAdapter` translating FastAPI WebSocket into expected interface.
+- Basic token verification via `WS_TOKEN` env var (default `devsecret`).
+- Startup event initializes the provided `VoiceServer`.
+- WebSocket endpoint delegates handling to `VoiceServer.handle_websocket`.

--- a/reports/todo_plan.md
+++ b/reports/todo_plan.md
@@ -1,51 +1,51 @@
 # TODO Work Plan
 
-## WS-Server / Backend
-1. **Unify TTS sanitization pipeline**
-   - **Files:** `ws_server/tts/text_sanitizer.py`, `ws_server/tts/text_normalize.py`
-   - **Priority:** Low
-   - **Dependencies:** none
-   - **Rationale:** Provides single entry point for text cleanup before chunking and synthesis.
-
-2. **Replace stubbed audio dependencies**
-   - **Files:** `torch.py`, `torchaudio.py`, `soundfile.py`, `piper/__init__.py`
-   - **Priority:** Low
-   - **Dependencies:** Availability of real libraries or test mocks.
-   - **Rationale:** Remove brittle stubs, enabling real audio processing and clearer tests.
-
-3. **Implement FastAPI transport adapter**
-   - **Files:** `ws_server/transport/fastapi_adapter.py`
-   - **Priority:** Low
-   - **Dependencies:** None
-   - **Rationale:** Allow HTTP clients to reuse WS server logic via FastAPI.
-
 ## Frontend
-4. **Merge VoiceAssistantCore & AudioStreamer**
+1. **Merge VoiceAssistantCore & AudioStreamer**
    - **Files:** `voice-assistant-apps/shared/core/VoiceAssistantCore.js`, `voice-assistant-apps/shared/core/AudioStreamer.js`
    - **Priority:** Medium
-   - **Dependencies:** None
-   - **Rationale:** Avoid duplicated streaming code across clients.
+   - **Domain:** Frontend
+   - **Dependencies:** none
+   - **Rationale:** eliminate duplicate streaming logic and centralize audio handling.
 
-5. **Consolidate GUI with shared core modules**
+2. **Consolidate GUI with shared core modules**
    - **Files:** `gui/enhanced-voice-assistant.js`
    - **Priority:** Medium
-   - **Dependencies:** Task 4 (shared streaming core ready)
-   - **Rationale:** Reduce duplication, align GUI with core logic.
+   - **Domain:** Frontend
+   - **Dependencies:** Task 1 (shared streaming core ready)
+   - **Rationale:** align GUI with unified core to reduce maintenance overhead.
 
-6. **GUI layout and design refresh**
+3. **GUI layout and design refresh**
    - **Files:** `gui/` assets
    - **Priority:** Low
-   - **Dependencies:** Task 5 to avoid merge conflicts
-   - **Rationale:** Improve user experience.
+   - **Domain:** Frontend
+   - **Dependencies:** Task 2 to avoid conflicts
+   - **Rationale:** improve usability and visual structure.
 
-7. **GUI animations (matrix-rain, avatar pulse)**
+4. **GUI animations (matrix-rain, avatar pulse, message flash)**
    - **Files:** `gui/` assets
    - **Priority:** Low
-   - **Dependencies:** Task 6 for final layout
-   - **Rationale:** Enhance visual feedback.
+   - **Domain:** Frontend
+   - **Dependencies:** Task 3 for finalized layout
+   - **Rationale:** enhance visual feedback and user engagement.
+
+## Backend / WS-Server
+5. **Implement FastAPI transport adapter**
+   - **Files:** `ws_server/transport/fastapi_adapter.py`
+   - **Priority:** Low
+   - **Domain:** WS-Server
+   - **Dependencies:** none
+   - **Rationale:** enable HTTP clients to reuse WebSocket server logic via FastAPI.
+
+6. **Replace stubbed audio dependencies**
+   - **Files:** `torch.py`, `torchaudio.py`, `soundfile.py`, `piper/__init__.py`
+   - **Priority:** Low
+   - **Domain:** Backend
+   - **Dependencies:** availability of real libraries or proper test mocks
+   - **Rationale:** remove brittle stubs and rely on real packages or scoped mocks.
 
 ## Open Questions
-- Are VoiceAssistantCore and AudioStreamer both needed or can they be merged?
+- Are VoiceAssistantCore and AudioStreamer both needed or can they be fully merged?
 - Is the legacy WS server still required, or can the compat layer be dropped?
 - Are the torch/torchaudio/soundfile stubs still necessary once real libraries are installed?
 - Is `gui/enhanced-voice-assistant.js` still required or can its features be merged into the shared core modules?

--- a/tests/unit/test_fastapi_adapter.py
+++ b/tests/unit/test_fastapi_adapter.py
@@ -1,0 +1,38 @@
+import pytest
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from ws_server.transport.fastapi_adapter import create_app
+
+
+class DummyVoiceServer:
+    def __init__(self) -> None:
+        self.initialized = False
+        self.handled = False
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+    async def handle_websocket(self, ws, path="/ws") -> None:  # pragma: no cover - dummy
+        self.handled = True
+        await ws.send("pong")
+
+
+def test_websocket_accepts_valid_token(monkeypatch):
+    vs = DummyVoiceServer()
+    app = create_app(vs)
+    monkeypatch.setenv("WS_TOKEN", "secret")
+    with TestClient(app) as client:
+        with client.websocket_connect("/ws?token=secret") as ws:
+            assert ws.receive_text() == "pong"
+    assert vs.initialized and vs.handled
+
+
+def test_websocket_rejects_invalid_token(monkeypatch):
+    vs = DummyVoiceServer()
+    app = create_app(vs)
+    monkeypatch.setenv("WS_TOKEN", "secret")
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/ws?token=wrong"):
+                pass

--- a/ws_server/transport/fastapi_adapter.py
+++ b/ws_server/transport/fastapi_adapter.py
@@ -1,10 +1,78 @@
-"""Placeholder for a future FastAPI transport adapter."""
+"""FastAPI transport adapter for the voice server."""
+# TODO-FIXED(2025-02-14): implement FastAPI transport adapter
+from __future__ import annotations
 
-# TODO: implement FastAPI transport to support HTTP clients
-#       (see TODO-Index.md: WS-Server / Protokolle)
+import os
+from typing import Optional, Protocol
 
-async def not_implemented(*_args, **_kwargs):  # pragma: no cover - stub
-    raise NotImplementedError("FastAPI adapter not yet implemented")
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Query
 
 
-__all__ = ["not_implemented"]
+def _verify_token(token: Optional[str]) -> bool:
+    expected = os.getenv("WS_TOKEN", "devsecret")
+    return token == expected
+
+
+class VoiceServerLike(Protocol):
+    async def initialize(self) -> None: ...
+    async def handle_websocket(self, ws, path: str = "/ws") -> None: ...
+
+
+class _WebSocketAdapter:
+    """Bridge FastAPI's WebSocket to the interface expected by ``VoiceServer``."""
+
+    def __init__(self, websocket: WebSocket) -> None:
+        self.websocket = websocket
+
+    @property
+    def remote_address(self) -> tuple[str, int]:
+        client = self.websocket.client
+        host = getattr(client, "host", "") if client else ""
+        port = getattr(client, "port", 0) if client else 0
+        return (host, port)
+
+    async def send(self, message: str) -> None:
+        await self.websocket.send_text(message)
+
+    def __aiter__(self) -> "_WebSocketAdapter":
+        return self
+
+    async def __anext__(self) -> str:
+        try:
+            return await self.websocket.receive_text()
+        except WebSocketDisconnect as exc:  # pragma: no cover - network disconnect
+            raise StopAsyncIteration from exc
+
+
+def create_app(voice_server: Optional[VoiceServerLike] = None) -> FastAPI:
+    """Return a FastAPI app serving the given voice server."""
+
+    if voice_server is None:
+        from .server import VoiceServer as _VoiceServer
+        vs = _VoiceServer()
+    else:
+        vs = voice_server
+    app = FastAPI()
+
+    @app.on_event("startup")
+    async def _startup() -> None:  # pragma: no cover - FastAPI lifecycle
+        await vs.initialize()
+
+    @app.websocket("/ws")
+    async def _ws_endpoint(websocket: WebSocket, token: Optional[str] = Query(None)) -> None:
+        if not _verify_token(token):
+            await websocket.close(code=4401, reason="unauthorized")
+            return
+
+        await websocket.accept()
+        adapter = _WebSocketAdapter(websocket)
+        try:
+            await vs.handle_websocket(adapter, path="/ws")
+        except Exception:  # pragma: no cover - passthrough
+            await websocket.close(code=1011, reason="server error")
+            raise
+
+    return app
+
+
+__all__ = ["create_app"]


### PR DESCRIPTION
## Summary
- implement FastAPI transport adapter with token verification and optional VoiceServer injection
- test adapter's token handling for valid and invalid clients

## Testing
- `ruff check ws_server/transport/fastapi_adapter.py tests/unit/test_fastapi_adapter.py`
- `pyright ws_server/transport/fastapi_adapter.py tests/unit/test_fastapi_adapter.py`
- `pytest tests/unit/test_fastapi_adapter.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a9ea9f1ba0832485b088419167024d