### PR TITLE
docs(todo): resolve open questions

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -41,5 +41,5 @@
 - **start_voice_assistant.py**: replace silent `pass` blocks with explicit error handling. ✅ Done in commit `startup error handling`. _Prio: Niedrig_
 
 ## ❓ Offene Fragen
-- ❓ Are VoiceAssistantCore and AudioStreamer both needed or can they be merged?
-- ❓ Is the legacy WS server still required, or can the compat layer be dropped?
+- **VoiceAssistantCore & AudioStreamer**: modules have distinct roles and remain separate. ✅ Decision documented in `reports/notes/core-audiostreamer-assessment.md`.
+- **legacy_ws_server compat layer**: still required because `ws_server/transport/server.py` imports it. ✅ Decision documented in `reports/notes/legacy-compat-layer.md`.

--- a/reports/notes/core-audiostreamer-assessment.md
+++ b/reports/notes/core-audiostreamer-assessment.md
@@ -1,0 +1,11 @@
+# VoiceAssistantCore vs AudioStreamer
+
+## Context
+Both modules reside under `voice-assistant-apps/shared/core/`. `VoiceAssistantCore` orchestrates UI state, connection handling and metrics. `AudioStreamer` focuses on low-level WebSocket audio streaming and playback.
+
+## Decision
+Modules serve distinct purposes and should remain separate. `VoiceAssistantCore` may delegate streaming to `AudioStreamer`, avoiding duplication.
+
+## Follow-up
+- Ensure integration between the classes stays documented.
+- Future refactor could expose a unified facade if duplication reappears.

--- a/reports/notes/legacy-compat-layer.md
+++ b/reports/notes/legacy-compat-layer.md
@@ -1,0 +1,11 @@
+# Legacy WS Compat Layer
+
+## Context
+`ws_server/transport/server.py` imports `ws_server.compat.legacy_ws_server` as the runtime server. This indicates that the compat layer is still the active implementation.
+
+## Decision
+Keep `legacy_ws_server` in place for now. Removing it would require a new server module exposing the same API. The TODO is marked as fixed with a note that the compat layer remains required until a replacement exists.
+
+## Follow-up
+- Introduce a modern server module and update transport to use it.
+- Once migrated, deprecate `ws_server/compat/legacy_ws_server.py`.

--- a/reports/todo_plan.md
+++ b/reports/todo_plan.md
@@ -1,28 +1,20 @@
 # TODO Work Plan
 
+## WS-Server
+1. **Clarify need for legacy compat layer**
+   - **Files:** `ws_server/compat/legacy_ws_server.py`, `ws_server/transport/server.py`
+   - **Priority:** High
+   - **Domain:** Backend / WS
+   - **Dependencies:** None
+   - **Rationale:** Determine if `legacy_ws_server` remains necessary or can be removed.
+
 ## Frontend
-1. **Unify GUI client with shared core modules**
-   - **Files:** `gui/enhanced-voice-assistant.js`, `gui/index.html`, `gui/app.js`
+1. **Assess merging of VoiceAssistantCore and AudioStreamer**
+   - **Files:** `voice-assistant-apps/shared/core/VoiceAssistantCore.js`, `voice-assistant-apps/shared/core/AudioStreamer.js`
    - **Priority:** Medium
    - **Domain:** Frontend
    - **Dependencies:** None
-   - **Rationale:** Avoid duplication by loading shared core modules directly.
+   - **Rationale:** Decide if streaming logic can be unified or modules kept separate.
 
-2. **GUI layout and design refresh**
-   - **Files:** `gui/` assets
-   - **Priority:** Low
-   - **Domain:** Frontend
-   - **Dependencies:** Task 1 provides stable base
-   - **Rationale:** Improve visual structure and usability.
-
-3. **GUI animations (matrix-rain, avatar pulse, message flash)**
-   - **Files:** `gui/` assets
-   - **Priority:** Low
-   - **Domain:** Frontend
-   - **Dependencies:** Task 2 finalizes layout foundation
-   - **Rationale:** Enhance visual feedback and engagement.
-
-## Open Questions
-- Are VoiceAssistantCore and AudioStreamer both needed or can they be fully merged?
-- Is the legacy WS server still required, or can the compat layer be dropped?
-- Is `gui/enhanced-voice-assistant.js` still required once the shared core is used?
+## Notes
+All other TODO entries in `TODO-Index.md` are already marked as completed.

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -19,8 +19,7 @@ Features integrated from previous versions:
 * Intent routing with optional Flowise/n8n calls (``aiohttp``)
 * Metrics API und TTS-Engine-Switching
 
-# TODO: clarify whether this legacy compat layer is still needed
-#       (see TODO-Index.md: ❓ Offene Fragen)
+# TODO-FIXED(2025-08-23): compat layer still required; transport server imports this module
 
 # Hinweis: Der TTS-Wechsel wird vom ``TTSManager`` verwaltet und
 # die Authentifizierung erfolgt über ``auth.token_utils``. Weitere


### PR DESCRIPTION
## Summary
- document decision to retain `legacy_ws_server` compat layer since transport still imports it
- clarify that `VoiceAssistantCore` and `AudioStreamer` handle different responsibilities and remain separate

## Testing
- `ruff check .`
- `npx -y pyright ws_server/compat/legacy_ws_server.py`
- `pytest -q`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f693207c8324bb034753a41f6d04