### PR TITLE
feat(gui): flash overlay on new text

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -12,7 +12,7 @@
 - **voice-assistant-apps/shared/core/AudioStreamer.js**: merge with VoiceAssistantCore for shared streaming logic. ✅ Done in commit `shared ws utils`. _Prio: Mittel_
 - **gui/enhanced-voice-assistant.js**: consolidate with shared core modules to avoid duplication. ✅ Done in commit `gui shared core`. _Prio: Mittel_
 - **gui layout and design refresh**: reorganize GUI elements (status page, input placement, icon-only round buttons). _Prio: Niedrig_
-- **gui animations**: implement matrix-rain response effect, avatar pulse, message flash. _Prio: Niedrig_
+- **gui animations**: implement matrix-rain response effect, avatar pulse, message flash. ✅ Done in commit `gui message flash`. _Prio: Niedrig_
 
 ## WS-Server / Protokolle
 - **ws_server/stt/in_memory.py**: implement streaming support without buffering entire audio. ✅ Done in commit `stt streaming`. _Prio: Hoch_

--- a/gui/app.js
+++ b/gui/app.js
@@ -96,8 +96,11 @@
     lastSeq = sequence_id || lastSeq || 'default';
     box.textContent = text || '';
     box.style.display = text ? 'block' : 'none';
-    // auto-fade nach 12s
     if (text) {
+      // TODO-FIXED(2025-08-23): message flash when new text appears
+      box.classList.add('flash');
+      box.addEventListener('animationend', () => box.classList.remove('flash'), { once: true });
+      // auto-fade nach 12s
       clearTimeout(box._hideTimer);
       box._hideTimer = setTimeout(()=>{ box.style.display='none'; }, 12000);
     }

--- a/gui/index.html
+++ b/gui/index.html
@@ -1154,24 +1154,33 @@
     }
 
     /* Landscape Orientation */
-    @media (orientation: landscape) and (max-height: 500px) {
-      .avatar {
-        width: 200px;
-        height: 200px;
+      @media (orientation: landscape) and (max-height: 500px) {
+        .avatar {
+          width: 200px;
+          height: 200px;
+        }
+
+        .main-content {
+          padding-bottom: 90px;
+        }
+
+        .header-section {
+          margin-bottom: var(--spacing-md);
+        }
       }
-      
-      .main-content {
-        padding-bottom: 90px;
+
+      #live-text-output.flash {
+        animation: messageFlash 0.8s var(--animation-easing);
       }
-      
-      .header-section {
-        margin-bottom: var(--spacing-md);
+
+      @keyframes messageFlash {
+        from { background: var(--accent-light); }
+        to { background: #1118; }
       }
-    }
-  </style>
-</head>
-<body>
-  <div class="app-container">
+    </style>
+  </head>
+  <body>
+    <div class="app-container">
     <!-- Top Navigation -->
     <nav class="top-nav">
       <div class="app-logo">

--- a/pull_requests/gui-message-flash.md
+++ b/pull_requests/gui-message-flash.md
@@ -1,0 +1,11 @@
+# Summary
+- add flash animation to live text overlay when new assistant text appears
+
+# Testing
+- `pytest -q`
+
+# Risk
+- Low: only touches GUI overlay styling and event handler
+
+# Rollback
+- Revert commit `feat(gui): flash overlay on new text`

--- a/reports/notes/gui-animations.md
+++ b/reports/notes/gui-animations.md
@@ -1,0 +1,10 @@
+# GUI Animations – Message Flash
+
+## Context
+Existing GUI implements matrix rain and avatar pulse but lacks a visual cue when new text arrives in the overlay.
+
+## Design
+- Add CSS `messageFlash` keyframes and `.flash` class.
+- Trigger flash when `assistant_text` event sets overlay text.
+- Remove class after animation to allow repeated flashes.
+- Style uses accent color fading back to transparent background.

--- a/reports/todo_plan.md
+++ b/reports/todo_plan.md
@@ -1,20 +1,15 @@
 # TODO Work Plan
 
-## WS-Server
-1. **Clarify need for legacy compat layer**
-   - **Files:** `ws_server/compat/legacy_ws_server.py`, `ws_server/transport/server.py`
-   - **Priority:** High
-   - **Domain:** Backend / WS
-   - **Dependencies:** None
-   - **Rationale:** Determine if `legacy_ws_server` remains necessary or can be removed.
-
-## Frontend
-1. **Assess merging of VoiceAssistantCore and AudioStreamer**
-   - **Files:** `voice-assistant-apps/shared/core/VoiceAssistantCore.js`, `voice-assistant-apps/shared/core/AudioStreamer.js`
-   - **Priority:** Medium
+## Frontend (GUI)
+1. **gui animations**
+   - **Files:** `gui/index.html`, `gui/app.js`
+   - **Priority:** Low
    - **Domain:** Frontend
    - **Dependencies:** None
-   - **Rationale:** Decide if streaming logic can be unified or modules kept separate.
-
-## Notes
-All other TODO entries in `TODO-Index.md` are already marked as completed.
+   - **Rationale:** Matrix rain and avatar pulse exist; add missing message flash effect for incoming text.
+2. **gui layout and design refresh**
+   - **Files:** `gui/index.html`, `styles`
+   - **Priority:** Low
+   - **Domain:** Frontend
+   - **Dependencies:** None
+   - **Rationale:** Further refine status section, input placement and button styling for cohesive layout.


### PR DESCRIPTION
## Summary
- add flash animation to live text overlay when new assistant text arrives
- document plan and note for GUI animations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9f827e1ac83248614e9a101fd5c5a