### PR TITLE
docs: add TODO index references for duplicate modules

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -7,6 +7,7 @@
 - **piper/__init__.py**: replace stub with real piper dependency. ✅ Done in commit `remove audio stubs`. _Prio: Niedrig_
 - **backend/tts/engine_zonos.py**: replace silent exception passes with explicit error handling for sanitizer import and speed conditioning. ✅ Done in commit `zonos error handling`. _Prio: Niedrig_
 - **backend/tts/base_tts_engine.py**: replace `pass` in abstract methods with `raise NotImplementedError` for clearer contracts. _Prio: Niedrig_
+- **ws_server/tts/engines/piper.py**: move implementation into `backend/tts` to keep engines centralized. _Prio: Niedrig_
 
 ## Frontend
 - **voice-assistant-apps/shared/core/VoiceAssistantCore.js**: consolidate with AudioStreamer to avoid duplicate streaming logic. ✅ Done in commit `shared ws utils`. _Prio: Mittel_
@@ -14,6 +15,8 @@
 - **gui/enhanced-voice-assistant.js**: consolidate with shared core modules to avoid duplication. ✅ Done in commit `gui shared core`. _Prio: Mittel_
 - **gui layout and design refresh**: reorganize GUI elements (status page, input placement, icon-only round buttons). ✅ Done in commit `gui layout refresh`. _Prio: Niedrig_
 - **gui animations**: implement matrix-rain response effect, avatar pulse, message flash. ✅ Done in commit `gui message flash`. _Prio: Niedrig_
+- **voice-assistant-apps/shared/core/VoiceAssistantCore.js**: deduplicate streaming logic with `AudioStreamer.js`. _Prio: Mittel_
+- **voice-assistant-apps/shared/core/AudioStreamer.js**: unify with `VoiceAssistantCore.js` to avoid duplicate streaming logic. _Prio: Mittel_
 
 ## WS-Server / Protokolle
 - **ws_server/stt/in_memory.py**: implement streaming support without buffering entire audio. ✅ Done in commit `stt streaming`. _Prio: Hoch_
@@ -29,11 +32,13 @@
 - **ws_server/compat/legacy_ws_server.py.backup.int_fix**: remove outdated backup file or merge changes into main compat module. ✅ Done in commit `remove legacy ws backup`. _Prio: Niedrig_
 - **archive/legacy_ws_server/skills/__init__.py**: implement BaseSkill methods or remove legacy skill module. ✅ Done in commit `remove legacy skills module`. _Prio: Niedrig_
 - **ws_server/compat/legacy_ws_server.py**: replace silent `pass` blocks in exception handlers with logging or explicit error handling. _Prio: Mittel_
+- **ws_server/compat/legacy_ws_server.py**: replace `DummyTTSManager.cleanup` stub with proper implementation or dedicated mock. _Prio: Niedrig_
 
 ## Config
 - **ws_server/tts/voice_aliases.py**: unify voice alias config with `config/tts.json` and environment. ✅ Done in commit `unify voice aliases`. _Prio: Niedrig_
 - **config/tts.json**: align with `voice_aliases.py` to remove duplication. ✅ Done in commit `unify voice aliases`. _Prio: Niedrig_
 - **env.example**: consolidate TTS defaults with `config/tts.json` to prevent drift. ✅ Done in commit `unify voice aliases`. _Prio: Niedrig_
+- **backend/tts/voice_aliases.py**: unify alias mapping with `ws_server/tts/voice_aliases.py` to avoid duplication. _Prio: Mittel_
 
 ## Dokumentation
 - **docs/Refaktorierungsplan.md**: add TODO stubs for true streaming. ✅ Done in commit `docs true streaming stubs`. _Prio: Niedrig_

--- a/backend/tts/voice_aliases.py
+++ b/backend/tts/voice_aliases.py
@@ -1,6 +1,8 @@
 """Voice alias mapping for TTS engines."""
 from __future__ import annotations
 
+# TODO: merge with ws_server/tts/voice_aliases.py to avoid configuration drift
+#       (see TODO-Index.md: Config/Voice aliases)
 from typing import Dict
 
 VOICE_ALIASES: Dict[str, str] = {

--- a/voice-assistant-apps/shared/core/AudioStreamer.js
+++ b/voice-assistant-apps/shared/core/AudioStreamer.js
@@ -13,6 +13,8 @@
 
 // TODO-FIXED(2025-08-23): shared auth token via ws-utils
 //       (see TODO-Index.md: Frontend)
+// TODO: unify with VoiceAssistantCore.js to avoid duplicate streaming logic
+//       (see TODO-Index.md: Frontend/Streaming)
 
 let getAuthToken;
 try {

--- a/voice-assistant-apps/shared/core/VoiceAssistantCore.js
+++ b/voice-assistant-apps/shared/core/VoiceAssistantCore.js
@@ -4,6 +4,8 @@
  *
  * TODO-FIXED(2025-08-23): consolidated auth token logic via shared ws-utils
  *       (see TODO-Index.md: Frontend)
+ * TODO: deduplicate streaming logic with AudioStreamer.js
+ *       (see TODO-Index.md: Frontend/Streaming)
  */
 
 let getAuthToken;

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -910,6 +910,8 @@ class VoiceServer:
                     from backend.tts.base_tts_engine import TTSResult
                     return TTSResult(success=False, error_message="TTS not available")
                 async def cleanup(self):
+                    # TODO: provide real cleanup or use dedicated mock
+                    #       (see TODO-Index.md: WS-Server / Legacy compatibility)
                     pass
                 def get_available_engines(self):
                     return []

--- a/ws_server/tts/engines/piper.py
+++ b/ws_server/tts/engines/piper.py
@@ -6,6 +6,9 @@ representation.  The engine reads the sample rate from the accompanying
 model JSON file and always returns proper WAV bytes.
 """
 
+# TODO: relocate to backend/tts to keep all engines in one place
+#       (see TODO-Index.md: Backend/TTS Engines)
+
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- track duplicate voice alias mappings and TTS engine placement in central TODO index
- note remaining duplication between VoiceAssistantCore and AudioStreamer
- document legacy DummyTTSManager cleanup stub

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68aa0510481c8324854125bab9cd785a