### PR TITLE
docs: track cleanup error TODOs

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -6,6 +6,7 @@
 - **torch.py / torchaudio.py / soundfile.py**: replace stub modules with real dependencies or dedicated mocks. ✅ Done in commit `remove audio stubs`. _Prio: Niedrig_
 - **piper/__init__.py**: replace stub with real piper dependency. ✅ Done in commit `remove audio stubs`. _Prio: Niedrig_
 - **backend/tts/engine_zonos.py**: replace silent exception passes with explicit error handling for sanitizer import and speed conditioning. ✅ Done in commit `zonos error handling`. _Prio: Niedrig_
+- **backend/tts/engine_zonos.py**: log voice scan and cleanup errors instead of silent `pass`. _Prio: Niedrig_
 - **backend/tts/base_tts_engine.py**: replace `pass` in abstract methods with `raise NotImplementedError` for clearer contracts. _Prio: Niedrig_
 - **ws_server/tts/engines/piper.py**: move implementation into `backend/tts` to keep engines centralized. _Prio: Niedrig_
 
@@ -47,6 +48,7 @@
 
 ## Tools & Scripts
 - **start_voice_assistant.py**: replace silent `pass` blocks with explicit error handling. ✅ Done in commit `startup error handling`. _Prio: Niedrig_
+- **debug_server_start.py**: log cleanup errors instead of bare `except: pass`. _Prio: Niedrig_
 
 ## ❓ Offene Fragen
 - **VoiceAssistantCore & AudioStreamer**: modules have distinct roles and remain separate. ✅ Decision documented in `reports/notes/core-audiostreamer-assessment.md`.

--- a/backend/tts/engine_zonos.py
+++ b/backend/tts/engine_zonos.py
@@ -237,6 +237,8 @@ class ZonosTTSEngine(BaseTTSEngine):
                         voices.append(fn[:-len(ext)])
                         break
         except Exception:
+            # TODO: log voice directory scan errors instead of silent pass
+            #       (see TODO-Index.md: Backend/Zonos engine)
             pass
         # Fallback: aktive Stimme wenigstens anbieten
         if self._active_voice and self._active_voice not in voices:
@@ -276,5 +278,7 @@ class ZonosTTSEngine(BaseTTSEngine):
                 import torch
                 torch.cuda.empty_cache()
         except Exception:
+            # TODO: log cleanup errors instead of silent pass
+            #       (see TODO-Index.md: Backend/Zonos engine)
             pass
     

--- a/debug_server_start.py
+++ b/debug_server_start.py
@@ -215,7 +215,9 @@ async def main():
     # Cleanup
     try:
         await server.tts_manager.cleanup()
-    except:
+    except Exception:
+        # TODO: log cleanup errors instead of using bare pass
+        #       (see TODO-Index.md: Tools/debug server)
         pass
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add TODO markers for Zonos voice scan and cleanup error handling
- note debug server cleanup TODO and reference central index
- update TODO-Index with new backend and tools entries

## Testing
- `PYTHONPATH=. ./run_tests.sh` *(fails: Required test coverage of 100% not reached; failing tests in token utils and tts modules)*

------
https://chatgpt.com/codex/tasks/task_e_68aa066b79248324a1bc5a3e6b0dc420