### PR TITLE
chore: refresh TODO index and add missing notes

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -1,56 +1,31 @@
 # 📌 Zentrale TODO-Übersicht
 
 ## Backend
-- **backend/tts/piper_tts_engine.py**: remove deprecated wrapper for Piper engine. ✅ Done in commit `remove piper wrapper`. _Prio: Niedrig_
-- **ws_server/tts/engines/piper.py**: handle sample rate read errors explicitly; backend wrapper removed. ✅ Done in commit `piper sample rate errors`. _Prio: Niedrig_
-- **torch.py / torchaudio.py / soundfile.py**: replace stub modules with real dependencies or dedicated mocks. ✅ Done in commit `remove audio stubs`. _Prio: Niedrig_
-- **piper/__init__.py**: replace stub with real piper dependency. ✅ Done in commit `remove audio stubs`. _Prio: Niedrig_
-- **backend/tts/engine_zonos.py**: replace silent exception passes with explicit error handling for sanitizer import and speed conditioning. ✅ Done in commit `zonos error handling`. _Prio: Niedrig_
-- **backend/tts/engine_zonos.py**: log voice scan and cleanup errors instead of silent `pass`. _Prio: Niedrig_
-- **backend/tts/base_tts_engine.py**: replace `pass` in abstract methods with `raise NotImplementedError` for clearer contracts. _Prio: Niedrig_
-- **ws_server/tts/engines/piper.py**: move implementation into `backend/tts` to keep engines centralized. _Prio: Niedrig_
+- **backend/tts/engine_zonos.py**: log voice directory scan errors instead of silent pass. _Prio: Niedrig_
+- **backend/tts/engine_zonos.py**: log cleanup errors instead of silent pass. _Prio: Niedrig_
+- **backend/tts/base_tts_engine.py**: raise `NotImplementedError` in abstract methods for clearer contracts. _Prio: Niedrig_
+- **ws_server/tts/engines/piper.py**: relocate implementation to `backend/tts` to keep engines centralized. _Prio: Niedrig_
 
 ## Frontend
-- **voice-assistant-apps/shared/core/VoiceAssistantCore.js**: consolidate with AudioStreamer to avoid duplicate streaming logic. ✅ Done in commit `shared ws utils`. _Prio: Mittel_
-- **voice-assistant-apps/shared/core/AudioStreamer.js**: merge with VoiceAssistantCore for shared streaming logic. ✅ Done in commit `shared ws utils`. _Prio: Mittel_
-- **gui/enhanced-voice-assistant.js**: consolidate with shared core modules to avoid duplication. ✅ Done in commit `gui shared core`. _Prio: Mittel_
-- **gui layout and design refresh**: reorganize GUI elements (status page, input placement, icon-only round buttons). ✅ Done in commit `gui layout refresh`. _Prio: Niedrig_
-- **gui animations**: implement matrix-rain response effect, avatar pulse, message flash. ✅ Done in commit `gui message flash`. _Prio: Niedrig_
 - **voice-assistant-apps/shared/core/VoiceAssistantCore.js**: deduplicate streaming logic with `AudioStreamer.js`. _Prio: Mittel_
 - **voice-assistant-apps/shared/core/AudioStreamer.js**: unify with `VoiceAssistantCore.js` to avoid duplicate streaming logic. _Prio: Mittel_
 
 ## WS-Server / Protokolle
-- **ws_server/stt/in_memory.py**: implement streaming support without buffering entire audio. ✅ Done in commit `stt streaming`. _Prio: Hoch_
-- **ws_server/compat/legacy_ws_server.py**: stream chunk-wise without buffering entire audio; log Kokoro voice detection errors instead of silent pass. ✅ Done in commit `legacy ws streaming`. _Prio: Mittel_
-- **ws_server/routing/skills.py**: flesh out skill interface and routing logic. ✅ Done in commit `skill interface abc`. _Prio: Hoch_
-- **ws_server/transport/fastapi_adapter.py**: implement FastAPI transport adapter. ✅ Done in commit `fastapi adapter`. _Prio: Niedrig_
-- **ws_server/tts/text_sanitizer.py**: unify sanitizer, normalizer and chunking pipeline. ✅ Done in commit `unify text pipeline`. _Prio: Niedrig_
-- **ws_server/tts/staged_tts/chunking.py**: review overlap with sanitizer/normalizer for unified pipeline. ✅ Done in commit `chunking pipeline unify`.
-- **ws_server/tts/text_normalize.py**: clarify responsibilities with other sanitizer components. ✅ Done in commit `unify text pipeline`. _Prio: Niedrig_
-- **ws_server/protocol/binary_v2.py**: verify PCM format and sample rate before processing. ✅ Done in commit `binary PCM validation`. _Prio: Hoch_
-- **ws_server/metrics/collector.py**: track memory usage and network throughput metrics. ✅ Done in commit `metrics network throughput`. _Prio: Mittel_
-- **ws_server/tts/staged_tts/staged_processor.py**: make crossfade duration configurable. ✅ Done in commit `staged tts crossfade env`. _Prio: Niedrig_
-- **ws_server/compat/legacy_ws_server.py.backup.int_fix**: remove outdated backup file or merge changes into main compat module. ✅ Done in commit `remove legacy ws backup`. _Prio: Niedrig_
-- **archive/legacy_ws_server/skills/__init__.py**: implement BaseSkill methods or remove legacy skill module. ✅ Done in commit `remove legacy skills module`. _Prio: Niedrig_
-- **ws_server/compat/legacy_ws_server.py**: replace silent `pass` blocks in exception handlers with logging or explicit error handling. _Prio: Mittel_
-- **ws_server/compat/legacy_ws_server.py**: replace `DummyTTSManager.cleanup` stub with proper implementation or dedicated mock. _Prio: Niedrig_
+- **ws_server/compat/legacy_ws_server.py**: legacy compatibility – log missing event loop, handle cleanup/close errors, and replace `DummyTTSManager` stub. _Prio: Mittel_
+- **ws_server/compat/legacy_ws_server.py**: legacy compatibility – plan migration away from this layer once transport server is updated. _Prio: Niedrig_
+- **ws_server/transport/fastapi_adapter.py**: add tests and consider merging into core transport server. _Prio: Niedrig_
+- **ws_server/tts/staged_tts/chunking.py**: streamline integration with `text_sanitizer`/`text_normalize` to reduce pipeline complexity. _Prio: Mittel_
 
 ## Config
-- **ws_server/tts/voice_aliases.py**: unify voice alias config with `config/tts.json` and environment. ✅ Done in commit `unify voice aliases`. _Prio: Niedrig_
-- **config/tts.json**: align with `voice_aliases.py` to remove duplication. ✅ Done in commit `unify voice aliases`. _Prio: Niedrig_
-- **env.example**: consolidate TTS defaults with `config/tts.json` to prevent drift. ✅ Done in commit `unify voice aliases`. _Prio: Niedrig_
-- **backend/tts/voice_aliases.py**: unify alias mapping with `ws_server/tts/voice_aliases.py` to avoid duplication. _Prio: Mittel_
+- **backend/tts/voice_aliases.py**: merge with `ws_server/tts/voice_aliases.py` to avoid configuration drift. _Prio: Mittel_
+- **config/tts.json**: deduplicate voice_map keys `de-thorsten-low` and `de_DE-thorsten-low`. _Prio: Niedrig_
 
 ## Dokumentation
-- **docs/Refaktorierungsplan.md**: add TODO stubs for true streaming. ✅ Done in commit `docs true streaming stubs`. _Prio: Niedrig_
-- **docs/GUI-TODO.md**: review and merge GUI tasks into central roadmap. ✅ Done in commit `gui todo merged`. _Prio: Niedrig_
 - **docs/Refaktorierungsplan.md**: flesh out true streaming section with concrete milestones. _Prio: Mittel_
 
 ## Tools & Scripts
-- **start_voice_assistant.py**: replace silent `pass` blocks with explicit error handling. ✅ Done in commit `startup error handling`. _Prio: Niedrig_
-- **debug_server_start.py**: log cleanup errors instead of bare `except: pass`. _Prio: Niedrig_
+- **debug_server_start.py**: log cleanup errors instead of bare pass. _Prio: Niedrig_
 
 ## ❓ Offene Fragen
-- **VoiceAssistantCore & AudioStreamer**: modules have distinct roles and remain separate. ✅ Decision documented in `reports/notes/core-audiostreamer-assessment.md`.
-- **legacy_ws_server compat layer**: still required because `ws_server/transport/server.py` imports it. ✅ Decision documented in `reports/notes/legacy-compat-layer.md`.
 - ❓ **ws_server/compat/legacy_ws_server.py**: is the embedded `DummyTTSManager` still needed or should a dedicated mock be used? _Prio: Niedrig_
+

--- a/config/tts.json
+++ b/config/tts.json
@@ -1,5 +1,7 @@
 {
   // TODO-FIXED(2025-08-23): unified with ws_server/tts/voice_aliases.py
+  // TODO: deduplicate voice keys 'de-thorsten-low' and 'de_DE-thorsten-low'
+  //       (see TODO-Index.md: Config)
   "default_engine": "piper",
   "engines": ["piper", "zonos"],
   "voice_map": {

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -20,6 +20,8 @@ Features integrated from previous versions:
 * Metrics API und TTS-Engine-Switching
 
 # TODO-FIXED(2025-08-23): compat layer still required; transport server imports this module
+# TODO: plan migration away from legacy compat layer once a new transport server
+#       exists (see TODO-Index.md: WS-Server / Protokolle)
 
 # Hinweis: Der TTS-Wechsel wird vom ``TTSManager`` verwaltet und
 # die Authentifizierung erfolgt über ``auth.token_utils``. Weitere

--- a/ws_server/transport/fastapi_adapter.py
+++ b/ws_server/transport/fastapi_adapter.py
@@ -1,5 +1,7 @@
 """FastAPI transport adapter for the voice server."""
 # TODO-FIXED(2025-02-14): implement FastAPI transport adapter
+# TODO: add tests and consider merging into core transport server
+#       (see TODO-Index.md: WS-Server / Protokolle)
 from __future__ import annotations
 
 import os

--- a/ws_server/tts/staged_tts/chunking.py
+++ b/ws_server/tts/staged_tts/chunking.py
@@ -7,6 +7,8 @@ from ws_server.tts.text_sanitizer import (
     pre_sanitize_text,
 )
 
+# TODO: streamline with text_sanitizer and text_normalize to reduce
+#       pipeline complexity (see TODO-Index.md: WS-Server / Protokolle)
 # TODO-FIXED(2024-06-01): rely solely on `pre_sanitize_text` for normalization
 # and expose public `limit_and_chunk` API to unify pipeline with sanitizer
 def limit_and_chunk(text: str, max_length: int = 500) -> List[str]:


### PR DESCRIPTION
## Summary
- remove completed tasks from TODO-Index and list remaining items by area
- note outstanding cleanup in legacy WebSocket server and FastAPI adapter
- highlight config and pipeline refinements with inline TODO markers

## Testing
- `pytest` *(fails: No module named 'aiohttp')*


------
https://chatgpt.com/codex/tasks/task_e_68aa077a5e188324bdfd98fb33f1aa13