### PR TITLE
docs: track tts manager fallback in TODO index

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -4,6 +4,7 @@
 - **backend/tts/engine_zonos.py**: log voice directory scan errors instead of silent pass. _Prio: Niedrig_
 - **backend/tts/engine_zonos.py**: log cleanup errors instead of silent pass. _Prio: Niedrig_
 - **backend/tts/base_tts_engine.py**: raise `NotImplementedError` in abstract methods for clearer contracts. _Prio: Niedrig_
+- **backend/tts/tts_manager.py**: replace `DummyTTSManager` fallback with dedicated mock or remove it. _Prio: Mittel_
 - **ws_server/tts/engines/piper.py**: relocate implementation to `backend/tts` to keep engines centralized. _Prio: Niedrig_
 
 ## Frontend
@@ -28,4 +29,5 @@
 
 ## ❓ Offene Fragen
 - ❓ **ws_server/compat/legacy_ws_server.py**: is the embedded `DummyTTSManager` still needed or should a dedicated mock be used? _Prio: Niedrig_
+- ❓ **backend/tts/tts_manager.py**: is `DummyTTSManager` sufficient as a fallback or should a proper mock be used? _Prio: Niedrig_
 

--- a/backend/tts/tts_manager.py
+++ b/backend/tts/tts_manager.py
@@ -395,8 +395,9 @@ class TTSManager:
         
         self.engines.clear()
         logger.info("TTS-Manager cleanup abgeschlossen")
-
 # Dummy TTS Manager für Fallback
+# TODO: replace with dedicated mock or remove if real engines are always available
+#       (see TODO-Index.md: Backend/TTS Manager)
 class DummyTTSManager:
     """Dummy TTS Manager wenn echte Engines nicht verfügbar"""
     


### PR DESCRIPTION
## Summary
- document DummyTTSManager fallback and reference TODO index
- expand central TODO-Index with TTS manager task and question

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa088fabe48324b7927b3e4f2d139c