### PR TITLE
docs: track tts pipeline consolidation

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -16,6 +16,7 @@
 - **ws_server/compat/legacy_ws_server.py**: legacy compatibility – plan migration away from this layer once transport server is updated. _Prio: Niedrig_
 - **ws_server/transport/fastapi_adapter.py**: add tests and consider merging into core transport server. _Prio: Niedrig_
 - **ws_server/tts/staged_tts/chunking.py**: streamline integration with `text_sanitizer`/`text_normalize` to reduce pipeline complexity. _Prio: Mittel_
+- **ws_server/tts/text_sanitizer.py** & **ws_server/tts/text_normalize.py**: clarify and consolidate responsibilities to avoid overlapping sanitization steps. _Prio: Mittel_
 
 ## Config
 - **backend/tts/voice_aliases.py**: merge with `ws_server/tts/voice_aliases.py` to avoid configuration drift. _Prio: Mittel_

--- a/ws_server/tts/text_normalize.py
+++ b/ws_server/tts/text_normalize.py
@@ -8,6 +8,8 @@ logger = logging.getLogger(__name__)
 # TODO-FIXED(2025-02-14): moved core logic into ``basic_sanitize`` and
 # delegated public ``sanitize_for_tts`` to ``text_sanitizer`` for a unified
 # pipeline
+# TODO: consolidate with text_sanitizer to avoid overlapping duties
+#       (see TODO-Index.md: WS-Server / Protokolle)
 
 ZERO_WIDTH = dict.fromkeys(map(ord, "\u200B\u200C\u200D\u200E\u200F\u2060\uFEFF"), None)
 TYPO_MAP = {

--- a/ws_server/tts/text_sanitizer.py
+++ b/ws_server/tts/text_sanitizer.py
@@ -3,6 +3,8 @@
 
 # TODO-FIXED(2025-02-14): now delegates basic normalisation to
 # ``text_normalize.basic_sanitize`` for a unified pipeline
+# TODO: consolidate with text_normalize to avoid duplicate sanitization
+#       (see TODO-Index.md: WS-Server / Protokolle)
 
 import re
 import unicodedata


### PR DESCRIPTION
## Summary
- document sanitization overlap in text_sanitizer and text_normalize
- extend central TODO index for TTS pipeline consolidation

## Testing
- `pytest` *(fails: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68aa0a3a3ce88324822e35ea3a2ca280