### PR TITLE
docs: refresh TODO index and remove resolved comments

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -6,13 +6,14 @@
 - **backend/tts/base_tts_engine.py**: raise `NotImplementedError` in abstract methods for clearer contracts. _Prio: Niedrig_
 - **backend/tts/tts_manager.py**: replace `DummyTTSManager` fallback with dedicated mock or remove it. _Prio: Mittel_
 - **ws_server/tts/engines/piper.py**: relocate implementation to `backend/tts` to keep engines centralized. _Prio: Niedrig_
+- **backend/tts/kokoro_tts_engine.py**: load voices from shared config to avoid duplication. _Prio: Niedrig_
 
 ## Frontend
 - **voice-assistant-apps/shared/core/VoiceAssistantCore.js**: deduplicate streaming logic with `AudioStreamer.js`. _Prio: Mittel_
 - **voice-assistant-apps/shared/core/AudioStreamer.js**: unify with `VoiceAssistantCore.js` to avoid duplicate streaming logic. _Prio: Mittel_
 
 ## WS-Server / Protokolle
-- **ws_server/compat/legacy_ws_server.py**: legacy compatibility – log missing event loop, handle cleanup/close errors, and replace `DummyTTSManager` stub. _Prio: Mittel_
+- **ws_server/compat/legacy_ws_server.py**: legacy compatibility – log missing event loop, handle missing torch dependency, cleanup/close errors, and replace `DummyTTSManager` stub. _Prio: Mittel_
 - **ws_server/compat/legacy_ws_server.py**: legacy compatibility – plan migration away from this layer once transport server is updated. _Prio: Niedrig_
 - **ws_server/transport/fastapi_adapter.py**: add tests and consider merging into core transport server. _Prio: Niedrig_
 - **ws_server/tts/staged_tts/chunking.py**: streamline integration with `text_sanitizer`/`text_normalize` to reduce pipeline complexity. _Prio: Mittel_
@@ -31,4 +32,5 @@
 ## ❓ Offene Fragen
 - ❓ **ws_server/compat/legacy_ws_server.py**: is the embedded `DummyTTSManager` still needed or should a dedicated mock be used? _Prio: Niedrig_
 - ❓ **backend/tts/tts_manager.py**: is `DummyTTSManager` sufficient as a fallback or should a proper mock be used? _Prio: Niedrig_
+- ❓ **docs/Code-und-Dokumentationsreview.md**: clarify whether `EnhancedVoiceAssistant.js` is still required or fully replaced by `VoiceAssistantCore`. _Prio: Niedrig_
 

--- a/backend/tts/engine_zonos.py
+++ b/backend/tts/engine_zonos.py
@@ -139,7 +139,6 @@ class ZonosTTSEngine(BaseTTSEngine):
                 from ws_server.tts.text_normalize import sanitize_for_tts
                 text = sanitize_for_tts(text)
             except Exception as e:
-                # TODO-FIXED(2025-08-23): log missing sanitizer instead of silent pass
                 logger.warning("Zonos: Textsanitizer nicht verfügbar: %s", e)
 
             voice = voice_id or self._active_voice
@@ -168,7 +167,6 @@ class ZonosTTSEngine(BaseTTSEngine):
                 try:
                     conditioning["rate"] = float(speed)
                 except Exception as e:
-                    # TODO-FIXED(2025-08-23): warn on invalid speed instead of silent pass
                     logger.warning("Zonos: Ungültiger Geschwindigkeitswert %s: %s", speed, e)
 
             use_fp16 = (self.device == 'cuda')

--- a/backend/tts/kokoro_tts_engine.py
+++ b/backend/tts/kokoro_tts_engine.py
@@ -52,6 +52,8 @@ class KokoroTTSEngine(BaseTTSEngine):
             # Weitere internationale Stimmen
             "bf_emma", "bf_isabella", "am_adam", "am_daniel"
         ]
+        # TODO: load voices from shared config to avoid duplication
+        #       (see TODO-Index.md: Backend/Kokoro engine)
         
         self.supported_languages = ["en", "en-US", "de", "de-DE", "multi"]
         

--- a/voice-assistant-apps/shared/core/AudioStreamer.js
+++ b/voice-assistant-apps/shared/core/AudioStreamer.js
@@ -11,8 +11,6 @@
  * - GPU-accelerated audio processing via WebAudio API
  */
 
-// TODO-FIXED(2025-08-23): shared auth token via ws-utils
-//       (see TODO-Index.md: Frontend)
 // TODO: unify with VoiceAssistantCore.js to avoid duplicate streaming logic
 //       (see TODO-Index.md: Frontend/Streaming)
 

--- a/voice-assistant-apps/shared/core/VoiceAssistantCore.js
+++ b/voice-assistant-apps/shared/core/VoiceAssistantCore.js
@@ -2,8 +2,6 @@
  * Voice Assistant Core with Audio Streaming & Mobile-First Design
  * Designed for low latency, real-time audio streaming, and mobile UX
  *
- * TODO-FIXED(2025-08-23): consolidated auth token logic via shared ws-utils
- *       (see TODO-Index.md: Frontend)
  * TODO: deduplicate streaming logic with AudioStreamer.js
  *       (see TODO-Index.md: Frontend/Streaming)
  */


### PR DESCRIPTION
## Summary
- remove completed TODO markers from Zonos engine and shared frontend components
- document Kokoro voice config duplication with TODO reference
- expand TODO-Index with Kokoro entry and legacy server torch note

## Testing
- `PYTHONPATH=. ./run_tests.sh --scope backend` *(fails: unrecognized arguments: --cov=ws_server.metrics.http_api --cov=ws_server.metrics.collector --cov=ws_server.metrics.perf_monitor --cov-fail-under=100)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0b8817f88324bc0c2bb76e35aa62