### PR TITLE
chore: tidy TODOs and refresh index

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -15,6 +15,7 @@
 ## WS-Server / Protokolle
 - **ws_server/compat/legacy_ws_server.py**: legacy compatibility – log missing event loop, handle missing torch dependency, cleanup/close errors, and replace `DummyTTSManager` stub. _Prio: Mittel_
 - **ws_server/compat/legacy_ws_server.py**: legacy compatibility – plan migration away from this layer once transport server is updated. _Prio: Niedrig_
+- **ws_server/protocol/json_v1.py**: deprecate `json_v1` in favour of `binary_v2` to avoid protocol fragmentation. _Prio: Niedrig_
 - **ws_server/transport/fastapi_adapter.py**: add tests and consider merging into core transport server. _Prio: Niedrig_
 - **ws_server/tts/staged_tts/chunking.py**: streamline integration with `text_sanitizer`/`text_normalize` to reduce pipeline complexity. _Prio: Mittel_
 - **ws_server/tts/text_sanitizer.py** & **ws_server/tts/text_normalize.py**: clarify and consolidate responsibilities to avoid overlapping sanitization steps. _Prio: Mittel_
@@ -22,6 +23,7 @@
 ## Config
 - **backend/tts/voice_aliases.py**: merge with `ws_server/tts/voice_aliases.py` to avoid configuration drift. _Prio: Mittel_
 - **config/tts.json**: deduplicate voice_map keys `de-thorsten-low` and `de_DE-thorsten-low`. _Prio: Niedrig_
+- **env.example**: deduplicate TTS defaults with `config/tts.json` to avoid confusion. _Prio: Niedrig_
 
 ## Dokumentation
 - **docs/Refaktorierungsplan.md**: flesh out true streaming section with concrete milestones. _Prio: Mittel_
@@ -33,4 +35,6 @@
 - ❓ **ws_server/compat/legacy_ws_server.py**: is the embedded `DummyTTSManager` still needed or should a dedicated mock be used? _Prio: Niedrig_
 - ❓ **backend/tts/tts_manager.py**: is `DummyTTSManager` sufficient as a fallback or should a proper mock be used? _Prio: Niedrig_
 - ❓ **docs/Code-und-Dokumentationsreview.md**: clarify whether `EnhancedVoiceAssistant.js` is still required or fully replaced by `VoiceAssistantCore`. _Prio: Niedrig_
+- ❓ **ws_server/protocol/json_v1.py**: maintain JSON v1 protocol or migrate entirely to `binary_v2`? _Prio: Niedrig_
+- ❓ **voice-assistant-apps/shared/workers/audio-streaming-worklet.js**: are multiple AudioWorklets necessary or can streaming be consolidated? _Prio: Niedrig_
 

--- a/config/tts.json
+++ b/config/tts.json
@@ -1,5 +1,4 @@
 {
-  // TODO-FIXED(2025-08-23): unified with ws_server/tts/voice_aliases.py
   // TODO: deduplicate voice keys 'de-thorsten-low' and 'de_DE-thorsten-low'
   //       (see TODO-Index.md: Config)
   "default_engine": "piper",

--- a/docs/Refaktorierungsplan.md
+++ b/docs/Refaktorierungsplan.md
@@ -175,7 +175,6 @@ sprint-5(tts): unify engine sources, add lazy loading and robust fallback
   - incremental Whisper chunking
   - forward partial transcripts to intent routing
   - stream TTS answers without full buffering
-<!-- TODO-FIXED(2024-07-06): true streaming TODO stubs added -->
 
 **Acceptance**
 

--- a/env.example
+++ b/env.example
@@ -14,7 +14,8 @@ STT_DEVICE=cpu
 STT_PRECISION=int8
 
 # === TTS Configuration ===
-# TODO-FIXED(2025-08-23): consolidated TTS defaults with config/tts.json
+# TODO: deduplicate TTS defaults with config/tts.json
+#       (see TODO-Index.md: Config/Environment)
 KOKORO_MODEL=kokoro-v1.0.int8.onnx
 KOKORO_LANG=en-us
 

--- a/gui/app.js
+++ b/gui/app.js
@@ -13,7 +13,6 @@
     } catch(e){ console.warn('[GUI] audio play failed', e); }
   }
 
-  // TODO-FIXED(2025-08-23): consolidated with shared VoiceAssistantCore
   async function ensureVA(){
     if (window.va) return window.va;
     if (!window.VoiceAssistantCore && !window.VoiceAssistant) {
@@ -97,7 +96,6 @@
     box.textContent = text || '';
     box.style.display = text ? 'block' : 'none';
     if (text) {
-      // TODO-FIXED(2025-08-23): message flash when new text appears
       box.classList.add('flash');
       box.addEventListener('animationend', () => box.classList.remove('flash'), { once: true });
       // auto-fade nach 12s

--- a/gui/index.html
+++ b/gui/index.html
@@ -1590,7 +1590,6 @@
   <!-- Notification Container -->
   <div class="notification-container" id="notificationContainer"></div>
 
-  <!-- TODO-FIXED(2025-08-23): layout refresh with status overlay -->
   <div class="status-page" id="statusPage">
     <div>
       <h2>Status</h2>
@@ -2476,7 +2475,6 @@
       }
     }
 
-    // TODO-FIXED(2025-08-23): dedicated status overlay
     function showStatusPage() {
       if (voiceAssistant) {
         const metrics = voiceAssistant.getMetrics();
@@ -2521,7 +2519,6 @@
   
   <!-- TTS Engine Controller -->
   <script src="tts-engine-controller.js"></script>
-  <!-- TODO-FIXED(2025-08-23): use shared VoiceAssistantCore instead of standalone build -->
   <script src="../voice-assistant-apps/shared/core/VoiceAssistantCore.js"></script>
   <script src="app.js"></script>
 

--- a/reports/notes/docs-true-streaming.md
+++ b/reports/notes/docs-true-streaming.md
@@ -5,5 +5,4 @@ Sprint 6 mentions STT in-memory streaming but lacks explicit TODOs for future tr
 
 ## Design
 - Add a clear TODO list under Sprint 6 outlining next steps toward real streaming STT.
-- Use HTML comment with TODO-FIXED tag to mark completion of this documentation update.
 - Keep existing structure; ensure wording stays concise and matches project tone.

--- a/reports/notes/tools-start_voice_assistant-error-handling.md
+++ b/reports/notes/tools-start_voice_assistant-error-handling.md
@@ -6,4 +6,3 @@
 ## Design
 - Replace `pass` with `print` logging that includes PID or operation context.
 - Keep process cleanup flow intact; do not re-raise to avoid stopping cleanup.
-- Annotate fixes with `# TODO-FIXED(2025-08-23)` for traceability.

--- a/start_voice_assistant.py
+++ b/start_voice_assistant.py
@@ -60,7 +60,7 @@ def kill_processes_on_ports(ports):
                                     try:
                                         os.kill(int(pid), signal.SIGKILL)
                                     except Exception as kill_err:
-                                        print(f"   Failed to force kill PID {pid}: {kill_err}")  # TODO-FIXED(2025-08-23): handle kill failure explicitly
+                                        print(f"   Failed to force kill PID {pid}: {kill_err}")
                             except Exception as pe:
                                 print(f"   PID extraction failed: {pe}")
         except Exception as e:
@@ -87,7 +87,7 @@ def kill_processes_on_ports(ports):
                                     time.sleep(0.2)
                                     os.kill(int(pid), signal.SIGKILL)
                                 except Exception as kill_err:
-                                    print(f"   lsof: Failed to kill PID {pid}: {kill_err}")  # TODO-FIXED(2025-08-23): handle kill failure explicitly
+                                    print(f"   lsof: Failed to kill PID {pid}: {kill_err}")
         except Exception as e:
             print(f"   lsof method failed: {e}")
 
@@ -185,7 +185,7 @@ def start_voice_assistant():
                         elif "STT model" in line and "loaded" in line:
                             print("   ✅ STT Model ready!")
             except Exception as read_err:
-                print(f"   Error reading server output: {read_err}")  # TODO-FIXED(2025-08-23): log subprocess read errors
+                print(f"   Error reading server output: {read_err}")
             
             # Test endpoints every 5 seconds after 15s
             if i > 15 and i % 5 == 0:

--- a/tests/unit/test_piper_model_resolution.py
+++ b/tests/unit/test_piper_model_resolution.py
@@ -2,8 +2,6 @@ import os
 from pathlib import Path
 
 import pytest
-
-# TODO-FIXED(2024-11-21): require real piper after removing stub
 pytest.importorskip("piper")
 
 from ws_server.tts.engines.piper import PiperTTSEngine

--- a/tests/unit/test_zonos_text_sanitization.py
+++ b/tests/unit/test_zonos_text_sanitization.py
@@ -1,8 +1,6 @@
 import asyncio
 import contextlib
 import pytest
-
-# TODO-FIXED(2024-11-21): guard heavy audio deps after removing stubs
 torch = pytest.importorskip("torch")
 torchaudio = pytest.importorskip("torchaudio")
 soundfile = pytest.importorskip("soundfile")

--- a/voice-assistant-apps/shared/workers/audio-streaming-worklet.js
+++ b/voice-assistant-apps/shared/workers/audio-streaming-worklet.js
@@ -1,6 +1,6 @@
 /**
  * 🎵 Enhanced Audio Streaming Worklet Processor
- * 
+ *
  * GPU-accelerated audio processing worklet with VAD support
  * Features:
  * - Real-time Voice Activity Detection (VAD)
@@ -9,6 +9,9 @@
  * - Binary frame preparation
  * - Performance monitoring
  */
+// TODO: clarify whether a separate AudioWorklet is still required or can be
+//       merged with main streaming logic
+//       (see TODO-Index.md: ❓/AudioWorklets)
 
 class AudioStreamingProcessor extends AudioWorkletProcessor {
     constructor(options) {

--- a/ws_server/compat/legacy_ws_server.py
+++ b/ws_server/compat/legacy_ws_server.py
@@ -18,8 +18,6 @@ Features integrated from previous versions:
 * STT audio pre-processing (in-memory ``numpy`` pipeline)
 * Intent routing with optional Flowise/n8n calls (``aiohttp``)
 * Metrics API und TTS-Engine-Switching
-
-# TODO-FIXED(2025-08-23): compat layer still required; transport server imports this module
 # TODO: plan migration away from legacy compat layer once a new transport server
 #       exists (see TODO-Index.md: WS-Server / Protokolle)
 
@@ -124,7 +122,6 @@ def _kokoro_voice_labels(voices_path: str, model_path: str):
             label = f"{pretty} [{k}]"
             out.append({"label": label, "key": k})
     except Exception as exc:
-        # TODO-FIXED(2025-08-23): log Kokoro voice detection errors instead of silent pass
         logger.error("Kokoro voice detection failed: %s", exc)
     return out
 
@@ -428,7 +425,6 @@ class AsyncSTTEngine:
         self, audio_data: bytes, *, stream_id: str = "", sequence: int = 0, **_kwargs
     ) -> dict | None:
         """Transcribe a PCM16 audio chunk without buffering the whole stream."""
-        # TODO-FIXED(2025-08-23): stream chunk-wise without buffering entire audio
         text = await self.transcribe_audio(audio_data)
         return {"text": text} if text else None
 
@@ -476,7 +472,7 @@ class AudioStreamManager:
         except RuntimeError:
             # wird in VoiceServer.initialize() gestartet
             # TODO: log missing event loop instead of silent pass
-            #       (see TODO-Index.md: WS-Server / Legacy compatibility)
+            #       (see TODO-Index.md: WS-Server / Protokolle)
             pass
 
     async def start_stream(self, client_id: str, response_callback) -> str:
@@ -913,7 +909,7 @@ class VoiceServer:
                     return TTSResult(success=False, error_message="TTS not available")
                 async def cleanup(self):
                     # TODO: provide real cleanup or use dedicated mock
-                    #       (see TODO-Index.md: WS-Server / Legacy compatibility)
+                    #       (see TODO-Index.md: WS-Server / Protokolle)
                     pass
                 def get_available_engines(self):
                     return []
@@ -1244,7 +1240,7 @@ class VoiceServer:
                 await websocket.close(code=4408, reason="handshake timeout")
             except Exception:
                 # TODO: handle close error instead of silent pass
-                #       (see TODO-Index.md: WS-Server / Legacy compatibility)
+                #       (see TODO-Index.md: WS-Server / Protokolle)
                 pass
         except websockets.exceptions.ConnectionClosed as e:
             logger.info(f"Client {client_id} connection closed: {e.code} {e.reason}")
@@ -1254,7 +1250,7 @@ class VoiceServer:
                 await websocket.close(code=1011, reason="server error")
             except Exception:
                 # TODO: handle server close error instead of silent pass
-                #       (see TODO-Index.md: WS-Server / Legacy compatibility)
+                #       (see TODO-Index.md: WS-Server / Protokolle)
                 pass
         finally:
             await self.connection_manager.unregister(client_id)
@@ -1756,7 +1752,7 @@ class VoiceServer:
                 gpu_available = torch.cuda.is_available()
             except ImportError:
                 # TODO: log missing torch dependency instead of pass
-                #       (see TODO-Index.md: WS-Server / Legacy compatibility)
+                #       (see TODO-Index.md: WS-Server / Protokolle)
                 pass
             
             # Hardware-optimized recommendations

--- a/ws_server/metrics/collector.py
+++ b/ws_server/metrics/collector.py
@@ -6,8 +6,6 @@ active connections, message counts and basic latency histograms.  It is
 intentionally lightweight to avoid blocking the event loop.
 """
 
-# TODO-FIXED(2025-08-23): track memory usage and network throughput metrics
-
 from __future__ import annotations
 
 import asyncio

--- a/ws_server/protocol/binary_v2.py
+++ b/ws_server/protocol/binary_v2.py
@@ -9,8 +9,6 @@ from dataclasses import dataclass
 from ws_server.metrics.collector import collector
 
 logger = logging.getLogger(__name__)
-
-# TODO-FIXED(2025-02-15): verify PCM format and sample rate before processing
 #       (see TODO-Index.md: WS-Server / Protokolle)
 
 SUPPORTED_SAMPLE_RATES = {16000, 44100, 48000}

--- a/ws_server/protocol/json_v1.py
+++ b/ws_server/protocol/json_v1.py
@@ -1,5 +1,8 @@
 """JSON based message helpers (protocol v1)."""
 
+# TODO: deprecate json_v1 in favour of binary_v2 to avoid protocol fragmentation
+#       (see TODO-Index.md: WS-Server / Protokolle)
+
 import json
 import logging
 from typing import Any, Dict

--- a/ws_server/routing/skills.py
+++ b/ws_server/routing/skills.py
@@ -16,13 +16,11 @@ class BaseSkill(ABC):
     @abstractmethod
     def can_handle(self, text: str) -> bool:
         """Return ``True`` if this skill can handle the given text."""
-        # TODO-FIXED(2024-11-24): enforce explicit intent matching contract
         ...
 
     @abstractmethod
     def handle(self, text: str) -> str:
         """Process the text and return a response string."""
-        # TODO-FIXED(2024-11-24): enforce explicit handler contract
         ...
 
 

--- a/ws_server/stt/in_memory.py
+++ b/ws_server/stt/in_memory.py
@@ -44,5 +44,3 @@ def iter_pcm16_stream(chunks: Iterable[bytes]) -> Iterator[np.ndarray]:
             yield pcm16_bytes_to_float32(bytes(buffer[:length]))
             del buffer[:length]
     # leftover byte (if any) is discarded silently; it cannot form a sample
-
-# TODO-FIXED(2025-08-23): add streaming support for chunked STT without buffering entire audio

--- a/ws_server/transport/fastapi_adapter.py
+++ b/ws_server/transport/fastapi_adapter.py
@@ -1,5 +1,4 @@
 """FastAPI transport adapter for the voice server."""
-# TODO-FIXED(2025-02-14): implement FastAPI transport adapter
 # TODO: add tests and consider merging into core transport server
 #       (see TODO-Index.md: WS-Server / Protokolle)
 from __future__ import annotations

--- a/ws_server/tts/engines/piper.py
+++ b/ws_server/tts/engines/piper.py
@@ -138,7 +138,6 @@ class PiperTTSEngine(BaseTTSEngine):
         sr = int(data.get("sample_rate", 0))
         if sr > 0:
             return sr
-        # TODO-FIXED(2024-11-21): handle sample rate JSON read errors explicitly
         if "de_DE-thorsten-low" in model_path:
             logger.warning("piper: sample_rate missing – fallback 22050 Hz")
             return 22050

--- a/ws_server/tts/staged_tts/chunking.py
+++ b/ws_server/tts/staged_tts/chunking.py
@@ -9,7 +9,6 @@ from ws_server.tts.text_sanitizer import (
 
 # TODO: streamline with text_sanitizer and text_normalize to reduce
 #       pipeline complexity (see TODO-Index.md: WS-Server / Protokolle)
-# TODO-FIXED(2024-06-01): rely solely on `pre_sanitize_text` for normalization
 # and expose public `limit_and_chunk` API to unify pipeline with sanitizer
 def limit_and_chunk(text: str, max_length: int = 500) -> List[str]:
     """

--- a/ws_server/tts/staged_tts/staged_processor.py
+++ b/ws_server/tts/staged_tts/staged_processor.py
@@ -43,7 +43,6 @@ class StagedTTSConfig:
     enable_caching: bool = True
     cache_size: int = 256
     crossfade_duration_ms: int = 100
-    # TODO-FIXED(2025-08-23): crossfade duration now configurable via env var
 
     @classmethod
     def from_env(cls) -> "StagedTTSConfig":

--- a/ws_server/tts/text_normalize.py
+++ b/ws_server/tts/text_normalize.py
@@ -4,8 +4,6 @@ import re
 import logging
 
 logger = logging.getLogger(__name__)
-
-# TODO-FIXED(2025-02-14): moved core logic into ``basic_sanitize`` and
 # delegated public ``sanitize_for_tts`` to ``text_sanitizer`` for a unified
 # pipeline
 # TODO: consolidate with text_sanitizer to avoid overlapping duties

--- a/ws_server/tts/text_sanitizer.py
+++ b/ws_server/tts/text_sanitizer.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 """Utility functions for strict text sanitization in the TTS pipeline."""
-
-# TODO-FIXED(2025-02-14): now delegates basic normalisation to
 # ``text_normalize.basic_sanitize`` for a unified pipeline
 # TODO: consolidate with text_normalize to avoid duplicate sanitization
 #       (see TODO-Index.md: WS-Server / Protokolle)

--- a/ws_server/tts/voice_aliases.py
+++ b/ws_server/tts/voice_aliases.py
@@ -8,8 +8,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional
 
-# TODO-FIXED(2025-08-23): unified with config/tts.json and environment defaults
-
 CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "tts.json"
 
 


### PR DESCRIPTION
## Summary
- clean up stale TODO-FIXED comments across code, tests, and docs
- document missing TODOs and add references to central index
- extend TODO-Index with config and protocol follow-ups

## Testing
- `pytest` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68aa0c980d148324a3edfdefc5810f4c