### PR TITLE
docs: expand todo index and annotate pipeline

### DIFF
--- a/TODO-Index.md
+++ b/TODO-Index.md
@@ -19,9 +19,10 @@
 - **ws_server/transport/fastapi_adapter.py**: add tests and consider merging into core transport server. _Prio: Niedrig_
 - **ws_server/tts/staged_tts/chunking.py**: streamline integration with `text_sanitizer`/`text_normalize` to reduce pipeline complexity. _Prio: Mittel_
 - **ws_server/tts/text_sanitizer.py** & **ws_server/tts/text_normalize.py**: clarify and consolidate responsibilities to avoid overlapping sanitization steps. _Prio: Mittel_
+- **ws_server/tts/staged_tts/staged_processor.py**: unify sanitizer and normalizer pipeline to reduce duplicate processing. _Prio: Mittel_
 
 ## Config
-- **backend/tts/voice_aliases.py**: merge with `ws_server/tts/voice_aliases.py` to avoid configuration drift. _Prio: Mittel_
+- **backend/tts/voice_aliases.py** & **ws_server/tts/voice_aliases.py**: merge to avoid configuration drift. _Prio: Mittel_
 - **config/tts.json**: deduplicate voice_map keys `de-thorsten-low` and `de_DE-thorsten-low`. _Prio: Niedrig_
 - **env.example**: deduplicate TTS defaults with `config/tts.json` to avoid confusion. _Prio: Niedrig_
 

--- a/ws_server/protocol/binary_v2.py
+++ b/ws_server/protocol/binary_v2.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from ws_server.metrics.collector import collector
 
 logger = logging.getLogger(__name__)
-#       (see TODO-Index.md: WS-Server / Protokolle)
 
 SUPPORTED_SAMPLE_RATES = {16000, 44100, 48000}
 

--- a/ws_server/tts/staged_tts/staged_processor.py
+++ b/ws_server/tts/staged_tts/staged_processor.py
@@ -84,6 +84,8 @@ class StagedTTSProcessor:
 
     async def process_staged_tts(self, text: str, canonical_voice: str) -> List[TTSChunk]:
         """Sanitize, chunk and synthesize text in stages."""
+        # TODO: unify sanitizer and normalizer steps to avoid duplicate processing
+        #       (see TODO-Index.md: WS-Server / Protokolle)
         text = sanitize_for_tts_strict(text)
         text = sanitize_basic(text)
 

--- a/ws_server/tts/voice_aliases.py
+++ b/ws_server/tts/voice_aliases.py
@@ -1,4 +1,6 @@
 """Voice alias configuration loader."""
+# TODO: merge with backend/tts/voice_aliases.py to avoid configuration drift
+#       (see TODO-Index.md: Config/Voice aliases)
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- annotate voice alias loader with merge TODO referencing index
- document sanitization/normalization pipeline TODO in staged processor
- tidy binary_v2 protocol file and expand central TODO index

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa15370c1483249e58b7b1a5afb39c