### PR TITLE
Handle short staged TTS responses without intro engine

### DIFF
--- a/tests/unit/test_staged_tts_short_text.py
+++ b/tests/unit/test_staged_tts_short_text.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from ws_server.tts.staged_tts.staged_processor import StagedTTSProcessor, StagedTTSConfig
+
+
+class OnlyZonosManager:
+    engines = {"zonos": object()}
+
+    async def synthesize(self, text, engine=None, voice=None):
+        if engine != "zonos":
+            raise ValueError("engine not available")
+
+        class R:
+            success = True
+            audio_data = b"x"
+            engine_used = engine
+            error_message = None
+            sample_rate = 22050
+            audio_format = "wav"
+
+        await asyncio.sleep(0)
+        return R()
+
+    def engine_allowed_for_voice(self, engine, voice):
+        return engine == "zonos"
+
+
+def test_short_text_without_intro_engine_uses_main_engine():
+    proc = StagedTTSProcessor(
+        OnlyZonosManager(),
+        StagedTTSConfig(max_intro_length=50, max_chunks=3),
+    )
+    text = "Hallo Welt"
+    chunks = asyncio.run(proc.process_staged_tts(text, "de-thorsten-low"))
+    assert len(chunks) == 1
+    chunk = chunks[0]
+    assert chunk.engine == "zonos"
+    assert chunk.index == 0
+    assert chunk.total == 1
+    assert chunk.text.startswith(text)


### PR DESCRIPTION
## Summary
- ensure staged TTS falls back to main engine when no intro engine is available
- test that short texts synthesize with Zonos even when Piper is missing

## Testing
- `pytest tests/unit/test_staged_tts_fallback.py tests/unit/test_staged_tts_env_override.py tests/unit/test_staged_tts_short_text.py --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68aa18bab87483248e84279da42cb76d