### PR TITLE
Fix staged TTS message format for client playback

### DIFF
--- a/tests/unit/test_staged_tts_crossfade.py
+++ b/tests/unit/test_staged_tts_crossfade.py
@@ -1,4 +1,7 @@
 from ws_server.tts.staged_tts.staged_processor import StagedTTSProcessor, TTSChunk
+import io
+import numpy as np
+import soundfile as sf
 
 
 class DummyManager:
@@ -8,6 +11,15 @@ class DummyManager:
 def test_crossfade_env_override(monkeypatch):
     monkeypatch.setenv("STAGED_TTS_CROSSFADE_MS", "250")
     proc = StagedTTSProcessor(DummyManager())
-    chunk = TTSChunk("x", 0, 1, "piper", "hi", b"x", True, 22050)
+
+    # generate tiny valid wav (silence)
+    buf = io.BytesIO()
+    sf.write(buf, np.zeros(22050, dtype=np.float32), 22050, format="WAV", subtype="PCM_16")
+    audio_bytes = buf.getvalue()
+
+    chunk = TTSChunk("x", 0, 1, "piper", "hi", audio_bytes, True, 22050)
     msg = proc.create_chunk_message(chunk)
     assert msg["crossfade_ms"] == 250
+    assert msg["op"] == "staged_tts_chunk"
+    assert msg["format"] == "f32"
+    assert msg["pcm"]


### PR DESCRIPTION
## Summary
- send `staged_tts_chunk` messages including raw float32 PCM and camelCase sampleRate for playback
- add test verifying chunk message format and crossfade override

## Testing
- `pytest tests/unit/test_staged_tts_crossfade.py tests/unit/test_staged_tts_fallback.py tests/unit/test_audio_throughput_metrics.py` *(fails: Required test coverage of 100% not reached. Total coverage: 61.82%)*
- `PYTEST_ADDOPTS="--cov=ws_server.metrics.http_api --cov=ws_server.metrics.collector --cov=ws_server.metrics.perf_monitor --cov-fail-under=0" pytest tests/unit/test_staged_tts_crossfade.py tests/unit/test_staged_tts_fallback.py tests/unit/test_audio_throughput_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa1f8f0c888324b8cb2c0156e68d4b