### PR TITLE
Handle missing PCM in staged TTS client

### DIFF
--- a/gui/staged-tts-client.js
+++ b/gui/staged-tts-client.js
@@ -63,9 +63,12 @@
           if (msg && msg.op === "staged_tts_chunk") {
             const sr = msg.sampleRate || SAMPLE_RATE;
             const fmt = (msg.format || "f32").toLowerCase();
-            if (fmt !== "f32") return; // wir behandeln hier nur f32
-            const pcm = b64ToFloat32(msg.pcm);
-            enqueueFloat32(pcm, sr);
+            if (fmt === "f32" && msg.pcm) {
+              const pcm = b64ToFloat32(msg.pcm);
+              enqueueFloat32(pcm, sr);
+            } else {
+              playTTSChunk(msg);
+            }
             return;
           }
           if (msg && msg.op === "staged_tts_end") {


### PR DESCRIPTION
## Summary
- Fallback to using data URL audio in staged TTS client when PCM payload is absent

## Testing
- `pytest tests/unit/test_staged_tts_env_override.py tests/unit/test_staged_tts_crossfade.py -q` (fails: Required test coverage of 100% not reached. Total coverage: 61.82%)

------
https://chatgpt.com/codex/tasks/task_e_68aa22e237388324b680dfaa7df3d1ce