### PR TITLE
Skip Piper init when model missing

### DIFF
--- a/tests/unit/test_skip_piper_when_model_missing.py
+++ b/tests/unit/test_skip_piper_when_model_missing.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+import sys
+import types
+
+from ws_server.tts.voice_aliases import VOICE_ALIASES, EngineVoice
+
+
+def test_piper_config_missing_model(monkeypatch):
+    alias = EngineVoice(model_path="does_not_exist.onnx")
+    monkeypatch.setitem(VOICE_ALIASES, "de-test", {"piper": alias})
+    cfg = SimpleNamespace(
+        default_tts_voice="de-test",
+        default_tts_speed=1.0,
+        default_tts_volume=1.0,
+        tts_model_dir="models",
+    )
+    # Stub schwergewichtige Abhängigkeiten
+    sys.modules.setdefault("faster_whisper", types.ModuleType("faster_whisper")).WhisperModel = object
+    sys.modules.setdefault("dotenv", types.ModuleType("dotenv")).load_dotenv = lambda *a, **k: None
+    from ws_server.compat.legacy_ws_server import _build_piper_config
+    assert _build_piper_config(cfg) is None


### PR DESCRIPTION
## Summary
- avoid initializing Piper when its model file isn't present
- adjust default engine fallback when Piper is unavailable
- add regression test for missing Piper model

## Testing
- `python -m pytest tests/unit/test_skip_piper_when_model_missing.py -q` *(fails: Coverage failure: total of 55 is less than fail-under=100)*

------
https://chatgpt.com/codex/tasks/task_e_68aa250570e88324a1da8982064582d1