### PR TITLE
fix: recognize de_DE Thorsten voice and robust Piper path

### DIFF
--- a/backend/tts/tts_manager.py
+++ b/backend/tts/tts_manager.py
@@ -151,7 +151,10 @@ class TTSManager:
         alias = VOICE_ALIASES.get(voice, {}).get("piper")
         model = alias.model_path if alias else None
         if not model:
-            logger.info('Piper deaktiviert: kein Modell für voice="%s" gefunden', voice)
+            logger.info(
+                'Piper deaktiviert: Kein Piper-Modell für voice=%s gefunden',
+                voice,
+            )
             return None
 
         model_dir = os.getenv("TTS_MODEL_DIR", self.config.model_dir)
@@ -166,7 +169,10 @@ class TTSManager:
             if home.exists():
                 mp = home
             else:
-                logger.info('Piper deaktiviert: kein Modell für voice="%s" gefunden', voice)
+                logger.info(
+                    'Piper deaktiviert: Kein Piper-Modell für voice=%s gefunden',
+                    voice,
+                )
                 return None
 
         return TTSConfig(
@@ -187,10 +193,18 @@ class TTSManager:
             raise ValueError(f"Voice '{canonical_voice}' not defined for engine '{engine}'")
         return ev
 
-    def engine_allowed_for_voice(self, engine: str, canonical_voice: str) -> bool:
+    def engine_allowed_for_voice(self, engine: str, voice: str) -> bool:
+        """Check if engine has mapping for given voice.
+
+        Accepts alias voices and resolves them to canonical form."""
+        canonical_voice = canonicalize_voice(voice)
         mapping = VOICE_ALIASES.get(canonical_voice, {})
         ev = mapping.get(engine)
         return bool(ev and (ev.voice_id or ev.model_path))
+
+    def get_canonical_voice(self, voice: str | None) -> str:
+        """Return canonical voice id using env fallback."""
+        return canonicalize_voice(voice or os.getenv("TTS_VOICE", "de-thorsten-low"))
 
     def _postprocess_audio(self, audio: bytes, sample_rate: int) -> tuple[bytes, int]:
         target_sr = int(os.getenv("TTS_TARGET_SR", sample_rate) or sample_rate)

--- a/config/tts.json
+++ b/config/tts.json
@@ -13,6 +13,18 @@
         "language": "de",
         "sample_rate": 48000
       }
+    },
+    "de_DE-thorsten-low": {
+      "piper": {
+        "model_path": "models/piper/de-thorsten-low.onnx",
+        "language": "de",
+        "sample_rate": 22050
+      },
+      "zonos": {
+        "voice_id": "thorsten",
+        "language": "de",
+        "sample_rate": 48000
+      }
     }
   },
   "playback": {

--- a/tests/unit/test_piper_model_resolution.py
+++ b/tests/unit/test_piper_model_resolution.py
@@ -63,3 +63,20 @@ def test_home_fallback(monkeypatch, tmp_path):
     cfg = TTSConfig(engine_type="piper", voice="de-thorsten-low")
     engine = PiperTTSEngine(cfg)
     assert engine._resolve_model_path("de-thorsten-low") == str(model.resolve())
+
+
+def test_resolve_alias_voice(monkeypatch, tmp_path):
+    models_dir = tmp_path / "models" / "piper"
+    models_dir.mkdir(parents=True)
+    model = models_dir / "de-thorsten-low.onnx"
+    model.write_bytes(b"0")
+    (model.with_suffix(".onnx.json")).write_text('{"sample_rate": 22050}')
+    monkeypatch.setenv("TTS_MODEL_DIR", str(tmp_path / "models"))
+    cfg = TTSConfig(
+        engine_type="piper",
+        voice="de_DE-thorsten-low",
+        model_path="models/piper/de-thorsten-low.onnx",
+    )
+    engine = PiperTTSEngine(cfg)
+    path = engine._resolve_model_path("de_DE-thorsten-low")
+    assert Path(path).name == "de-thorsten-low.onnx"

--- a/tests/unit/test_voice_alias_mapping.py
+++ b/tests/unit/test_voice_alias_mapping.py
@@ -1,0 +1,9 @@
+from ws_server.tts.voice_aliases import VOICE_ALIASES
+from ws_server.tts.voice_utils import canonicalize_voice
+
+
+def test_alias_mapping_contains_locale_variant():
+    v = canonicalize_voice('de_DE-thorsten-low')
+    assert v in VOICE_ALIASES
+    mapping = VOICE_ALIASES[v]
+    assert 'piper' in mapping and 'zonos' in mapping

--- a/ws_server/tts/staged_tts/staged_processor.py
+++ b/ws_server/tts/staged_tts/staged_processor.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional
 from ws_server.metrics.collector import collector
 from ws_server.tts.text_sanitizer import sanitize_for_tts_strict, pre_clean_for_piper
 from ws_server.tts.text_normalize import sanitize_for_tts as sanitize_basic
+from ws_server.tts.voice_utils import canonicalize_voice
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,7 @@ class StagedTTSProcessor:
 
     async def process_staged_tts(self, text: str, canonical_voice: str) -> List[TTSChunk]:
         """Sanitize, chunk and synthesize text in stages."""
+        canonical_voice = canonicalize_voice(canonical_voice)
         # TODO: unify sanitizer and normalizer steps to avoid duplicate processing
         #       (see TODO-Index.md: WS-Server / Protokolle)
         text = sanitize_for_tts_strict(text)
@@ -283,8 +285,6 @@ class StagedTTSProcessor:
         }
 
     def _engine_available_for_voice(self, engine: str, voice: str) -> bool:
-        from ws_server.tts.voice_utils import canonicalize_voice
-
         try:
             engines = getattr(self.tts_manager, "engines", {})
             engine_obj = engines.get(engine)


### PR DESCRIPTION
## Summary
- map `de_DE-thorsten-low` to Piper and Zonos in TTS config
- canonicalize voice ids in TTS manager and staged processor
- resolve Piper models with canonical voice aliases

## Testing
- `pytest tests/unit/test_voice_alias_mapping.py tests/unit/test_piper_model_resolution.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68aa36962d7083249cbd7bddee34740e