### PR TITLE
feat(tts): canonicalize voice alias and add model check script

### DIFF
--- a/scripts/check_piper_model.py
+++ b/scripts/check_piper_model.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Check for presence of the default Piper model."""
+from __future__ import annotations
+
+from pathlib import Path
+
+CANDIDATES = [
+    Path("models/piper/de-thorsten-low.onnx"),
+    Path.home() / ".local" / "share" / "piper" / "de-thorsten-low.onnx",
+]
+
+
+def main() -> None:
+    for candidate in CANDIDATES:
+        if candidate.exists():
+            print(f"\u2705 Piper model found: {candidate}")
+            return
+    print("\u274c Piper model missing. Expected one of:")
+    for c in CANDIDATES:
+        print(f" - {c}")
+    raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_voice_alias_mapping.py
+++ b/tests/unit/test_voice_alias_mapping.py
@@ -1,9 +1,25 @@
-from ws_server.tts.voice_aliases import VOICE_ALIASES
+from pathlib import Path
+
+import pytest
+
+from ws_server.tts.voice_aliases import VOICE_ALIASES, _load_jsonc
 from ws_server.tts.voice_utils import canonicalize_voice
 
 
-def test_alias_mapping_contains_locale_variant():
-    v = canonicalize_voice('de_DE-thorsten-low')
+@pytest.fixture
+def load_voice_map() -> dict:
+    cfg = Path(__file__).resolve().parents[2] / "config" / "tts.json"
+    data = _load_jsonc(cfg)
+    return data["voice_map"]
+
+
+def test_alias_mapping_contains_locale_variant(load_voice_map):
+    vm = load_voice_map
+    assert "de-thorsten-low" in vm
+    assert "de_DE-thorsten-low" in vm
+    for eng in ("piper", "zonos"):
+        assert eng in vm["de-thorsten-low"]
+        assert eng in vm["de_DE-thorsten-low"]
+
+    v = canonicalize_voice("de_DE-thorsten-low")
     assert v in VOICE_ALIASES
-    mapping = VOICE_ALIASES[v]
-    assert 'piper' in mapping and 'zonos' in mapping

--- a/ws_server/tts/voice_utils.py
+++ b/ws_server/tts/voice_utils.py
@@ -5,18 +5,16 @@ from __future__ import annotations
 from typing import Optional
 
 
-def canonicalize_voice(voice: Optional[str]) -> str:
+def canonicalize_voice(voice: Optional[str]) -> Optional[str]:
     """Return canonical voice identifier.
 
-    Normalizes locale prefixes like ``de_DE-`` to ``de-`` and strips
+    Normalizes locale-style prefixes like ``de_DE-`` to ``de-`` and strips
     surrounding whitespace.  The function is intentionally minimal and can be
     extended with more rules as new voices are added.
     """
     if not voice:
-        return ""
-    v = voice.strip().lower()
-    if v.startswith("de_de-"):
-        v = "de-" + v[len("de_de-") :]
-    return v
+        return voice
+    v = voice.strip().replace("de_DE-", "de-")
+    return v.lower()
 
 __all__ = ["canonicalize_voice"]


### PR DESCRIPTION
## Summary
- canonicalize locale-style voice identifiers to canonical forms
- add test ensuring `de_DE-thorsten-low` is mapped for Piper and Zonos
- provide helper script to verify Piper model presence

## Testing
- `pytest -q tests/unit/test_voice_alias_mapping.py tests/unit/test_piper_model_resolution.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68aa37b84e0c8324aa98ab71a1a111cb