### PR TITLE
fix: Voice alias fallback for Zonos mapping

### DIFF
--- a/backend/tts/tts_manager.py
+++ b/backend/tts/tts_manager.py
@@ -198,7 +198,9 @@ class TTSManager:
 
         Accepts alias voices and resolves them to canonical form."""
         canonical_voice = canonicalize_voice(voice)
-        mapping = VOICE_ALIASES.get(canonical_voice, {})
+        mapping = VOICE_ALIASES.get(canonical_voice) or VOICE_ALIASES.get(voice)
+        if not mapping:
+            return False
         ev = mapping.get(engine)
         return bool(ev and (ev.voice_id or ev.model_path))
 

--- a/tests/unit/test_tts_manager_alias_fallback.py
+++ b/tests/unit/test_tts_manager_alias_fallback.py
@@ -1,0 +1,12 @@
+from backend.tts.tts_manager import TTSManager
+from ws_server.tts.voice_aliases import EngineVoice
+
+
+def test_engine_allowed_for_voice_alias_fallback(monkeypatch):
+    mgr = TTSManager()
+    alias_map = {
+        "de_DE-thorsten-low": {"zonos": EngineVoice(voice_id="thorsten", language="de")}
+    }
+    monkeypatch.setattr("backend.tts.tts_manager.VOICE_ALIASES", alias_map)
+    assert mgr.engine_allowed_for_voice("zonos", "de_DE-thorsten-low") is True
+    assert mgr.engine_allowed_for_voice("piper", "de_DE-thorsten-low") is False


### PR DESCRIPTION
## Summary
- ensure engine voice lookup falls back to original alias if canonical key is missing
- cover alias fallback in TTS manager with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa3dad9fd08324b07170a351b1594b