### PR TITLE
Normalize voice IDs and expand aliases for TTS

### DIFF
--- a/backend/tts/tts_manager.py
+++ b/backend/tts/tts_manager.py
@@ -372,9 +372,10 @@ class TTSManager:
         if target_engine_name not in self.engines:
             logger.warning(f"Engine '{target_engine_name}' nicht verfügbar")
             return False
-            
+
         try:
             engine_obj = self.engines[target_engine_name]
+            voice = canonicalize_voice(voice)
             # Setze Voice in der Engine (falls unterstützt)
             if hasattr(engine_obj, 'set_voice'):
                 return await engine_obj.set_voice(voice)

--- a/tests/unit/test_tts_manager_voice_param.py
+++ b/tests/unit/test_tts_manager_voice_param.py
@@ -24,6 +24,10 @@ class FakePiper:
             processing_time_ms = 0.0
         return R()
 
+    async def set_voice(self, voice):
+        self.calls.append(voice)
+        return True
+
 
 def test_tts_manager_passes_voice(monkeypatch):
     fake_mod = types.ModuleType("fake_piper")
@@ -40,4 +44,22 @@ def test_tts_manager_passes_voice(monkeypatch):
     p_cfg = TTSConfig(engine_type="piper")
     asyncio.run(mgr.initialize(piper_config=p_cfg, default_engine=TTSEngineType.PIPER))
     asyncio.run(mgr.synthesize("hi", voice="de_DE-thorsten-low"))
+    assert mgr.engines["piper"].calls[-1] == "de-thorsten-low"
+
+
+def test_tts_manager_set_voice_canonicalization(monkeypatch):
+    fake_mod = types.ModuleType("fake_piper")
+    fake_mod.FakePiper = FakePiper
+    sys.modules["fake_piper"] = fake_mod
+    monkeypatch.setattr(
+        tts_manager,
+        "ENGINE_IMPORTS",
+        {"piper": ("fake_piper", "FakePiper")},
+        raising=False,
+    )
+
+    mgr = TTSManager()
+    p_cfg = TTSConfig(engine_type="piper")
+    asyncio.run(mgr.initialize(piper_config=p_cfg, default_engine=TTSEngineType.PIPER))
+    asyncio.run(mgr.set_voice("de_DE-thorsten-low", TTSEngineType.PIPER))
     assert mgr.engines["piper"].calls[-1] == "de-thorsten-low"

--- a/tests/unit/test_voice_alias_auto_expand.py
+++ b/tests/unit/test_voice_alias_auto_expand.py
@@ -1,0 +1,15 @@
+from ws_server.tts.voice_aliases import _build_aliases
+
+
+def test_auto_expands_locale_alias(monkeypatch):
+    data = {
+        "voice_map": {
+            "de-thorsten-low": {
+                "zonos": {"voice_id": "thorsten", "language": "de"}
+            }
+        }
+    }
+    monkeypatch.setattr('ws_server.tts.voice_aliases._load_jsonc', lambda path: data)
+    aliases = _build_aliases()
+    assert 'de-thorsten-low' in aliases
+    assert 'de_DE-thorsten-low' in aliases

--- a/ws_server/tts/voice_aliases.py
+++ b/ws_server/tts/voice_aliases.py
@@ -33,7 +33,14 @@ def _build_aliases() -> Dict[str, Dict[str, EngineVoice]]:
     result: Dict[str, Dict[str, EngineVoice]] = {}
     for alias, engines in data.get("voice_map", {}).items():
         result[alias] = {eng: EngineVoice(**cfg) for eng, cfg in engines.items()}
-    return result
+
+    expanded = dict(result)
+    for key, engines in result.items():
+        if "-" in key and "_" not in key:
+            lang, rest = key.split("-", 1)
+            alias = f"{lang}_{lang.upper()}-{rest}"
+            expanded.setdefault(alias, engines)
+    return expanded
 
 
 VOICE_ALIASES: Dict[str, Dict[str, EngineVoice]] = _build_aliases()


### PR DESCRIPTION
## Summary
- auto-expand locale-specific voice aliases like `de_DE-thorsten-low`
- normalize voices in `set_voice` to ensure consistent engine resolution
- add unit tests for alias expansion and voice normalization

## Testing
- `pytest --override-ini addopts= tests/unit/test_voice_alias_auto_expand.py tests/unit/test_tts_manager_voice_param.py::test_tts_manager_set_voice_canonicalization -q`
- `pytest --override-ini addopts= tests/unit/test_tts_manager_voice_param.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa4358e76c8324ab31aa5ee9d2e5f3