### PR TITLE
desktop: remove duplicate electron imports

### DIFF
--- a/voice-assistant-apps/desktop/src/main.js
+++ b/voice-assistant-apps/desktop/src/main.js
@@ -1,18 +1,15 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, Menu, dialog, shell, Tray, nativeImage, ipcMain } = require('electron');
 const path = require('path');
 const fs = require('fs');
-
-app.disableHardwareAcceleration(); // vermeidet GLib/GPU Zicken
-const { app, BrowserWindow, Menu, dialog, shell, Tray, nativeImage, ipcMain } = require('electron');
-const path   = require('path');
-const fs     = require('fs');
 const { spawn } = require('child_process');
-const log    = require('electron-log');
+const log = require('electron-log');
 log.info('Desktop app starting');
 const { autoUpdater } = require('electron-updater');
 const dotenv = require('dotenv');
-const http   = require('http');
-const url    = require('url');
+const http = require('http');
+const url = require('url');
+
+app.disableHardwareAcceleration(); // vermeidet GLib/GPU Zicken
 
 const SHOULD_SPAWN = !process.env.SKIP_BACKEND_SPAWN && !process.env.BACKEND_URL;
 


### PR DESCRIPTION
## Summary
- fix desktop startup by consolidating Electron imports and removing duplicate declarations

## Testing
- `node --check voice-assistant-apps/desktop/src/main.js`
- `npm start` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68af0504930c8324b197ae7b21f60eb5